### PR TITLE
Renamed dummy service for ServiceLoaderTest due to problems with Surefire

### DIFF
--- a/api-tests/src/test/java/com/ocpsoft/rewrite/services/DummyService.java
+++ b/api-tests/src/test/java/com/ocpsoft/rewrite/services/DummyService.java
@@ -19,7 +19,7 @@ package com.ocpsoft.rewrite.services;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  *
  */
-public class TestServiceImpl implements TestService
+public interface DummyService
 {
 
 }

--- a/api-tests/src/test/java/com/ocpsoft/rewrite/services/DummyServiceImpl.java
+++ b/api-tests/src/test/java/com/ocpsoft/rewrite/services/DummyServiceImpl.java
@@ -19,7 +19,7 @@ package com.ocpsoft.rewrite.services;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  *
  */
-public interface TestService
+public class DummyServiceImpl implements DummyService
 {
 
 }

--- a/api-tests/src/test/java/com/ocpsoft/rewrite/services/ServiceLoaderTest.java
+++ b/api-tests/src/test/java/com/ocpsoft/rewrite/services/ServiceLoaderTest.java
@@ -33,8 +33,8 @@ public class ServiceLoaderTest
    @SuppressWarnings("unchecked")
    public void test()
    {
-      ServiceLoader<TestService> services = ServiceLoader.load(TestService.class);
-      List<TestService> list = Iterators.asList(services);
+      ServiceLoader<DummyService> services = ServiceLoader.load(DummyService.class);
+      List<DummyService> list = Iterators.asList(services);
       Assert.assertFalse(list.isEmpty());
    }
 }

--- a/api-tests/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.DummyService
+++ b/api-tests/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.DummyService
@@ -1,0 +1,1 @@
+com.ocpsoft.rewrite.services.DummyServiceImpl

--- a/api-tests/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.TestService
+++ b/api-tests/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.TestService
@@ -1,1 +1,0 @@
-com.ocpsoft.rewrite.services.TestServiceImpl

--- a/api/src/test/java/com/ocpsoft/rewrite/services/DummyService.java
+++ b/api/src/test/java/com/ocpsoft/rewrite/services/DummyService.java
@@ -19,7 +19,7 @@ package com.ocpsoft.rewrite.services;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  *
  */
-public class TestServiceImpl implements TestService
+public interface DummyService
 {
 
 }

--- a/api/src/test/java/com/ocpsoft/rewrite/services/DummyServiceImpl.java
+++ b/api/src/test/java/com/ocpsoft/rewrite/services/DummyServiceImpl.java
@@ -19,7 +19,7 @@ package com.ocpsoft.rewrite.services;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  *
  */
-public interface TestService
+public class DummyServiceImpl implements DummyService
 {
 
 }

--- a/api/src/test/java/com/ocpsoft/rewrite/services/ServiceLoaderTest.java
+++ b/api/src/test/java/com/ocpsoft/rewrite/services/ServiceLoaderTest.java
@@ -33,8 +33,8 @@ public class ServiceLoaderTest
    @SuppressWarnings("unchecked")
    public void test()
    {
-      ServiceLoader<TestService> services = ServiceLoader.load(TestService.class);
-      List<TestService> list = Iterators.asList(services);
+      ServiceLoader<DummyService> services = ServiceLoader.load(DummyService.class);
+      List<DummyService> list = Iterators.asList(services);
       Assert.assertFalse(list.isEmpty());
    }
 }

--- a/api/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.DummyService
+++ b/api/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.DummyService
@@ -1,0 +1,1 @@
+com.ocpsoft.rewrite.services.DummyServiceImpl

--- a/api/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.TestService
+++ b/api/src/test/resources/META-INF/services/com.ocpsoft.rewrite.services.TestService
@@ -1,1 +1,0 @@
-com.ocpsoft.rewrite.services.TestServiceImpl


### PR DESCRIPTION
Hey Lincoln,

The rewrite-api unit tests are failing for me if I run Maven from the console (Maven 3.0.1). It seems like Surefire tries to execute TestServiceImpl (a dummy service for testing ServiceLoader) as a test and fails because it doesn't contain @Test annotated methods:

```
initializationError(com.ocpsoft.rewrite.services.TestServiceImpl)  Time elapsed: 0.024 sec  <<< ERROR!
java.lang.Exception: No runnable methods
        at org.junit.runners.BlockJUnit4ClassRunner.validateInstanceMethods(BlockJUnit4ClassRunner.java:171)
        at org.junit.runners.BlockJUnit4ClassRunner.collectInitializationErrors(BlockJUnit4ClassRunner.java:115)
        at org.junit.runners.ParentRunner.validate(ParentRunner.java:269)
        at org.junit.runners.ParentRunner.<init>(ParentRunner.java:66)
```

I fixed this my renaming the TestServiceImpl to DummyServiceImpl. Now the tests run fine on my box.

BTW: There seem to be the duplicated unit tests in api/src/test/java and api-tests/src/test/java.
