### PR TITLE
NPE for query parameters without a value

### DIFF
--- a/impl-servlet/src/main/java/com/ocpsoft/rewrite/servlet/util/QueryStringBuilder.java
+++ b/impl-servlet/src/main/java/com/ocpsoft/rewrite/servlet/util/QueryStringBuilder.java
@@ -234,7 +234,9 @@ public class QueryStringBuilder
          String key = handler.encode(entry.getKey());
          List<String> values = new ArrayList<String>();
          for (String value : entry.getValue()) {
-            values.add(handler.encode(value));
+            if (value != null) {
+               values.add(handler.encode(value));
+            }
          }
          map.put(key, new ArrayList<String>(values));
       }


### PR DESCRIPTION
For an URL like this:

```
http://localhost:8080/myapp/test?foo
```

I'm getting the following exception:

```
WARNUNG: Failed to encode URL [test.html?1317654009799]
java.lang.NullPointerException
    at java.net.URLDecoder.decode(URLDecoder.java:119)
    at com.ocpsoft.rewrite.servlet.util.QueryStringBuilder$QSDecoder.encode(QueryStringBuilder.java:376)
    at com.ocpsoft.rewrite.servlet.util.QueryStringBuilder.getParameterMap(QueryStringBuilder.java:238)
    at com.ocpsoft.rewrite.servlet.util.QueryStringBuilder.decode(QueryStringBuilder.java:187)
    at com.ocpsoft.rewrite.servlet.util.URLBuilder.decode(URLBuilder.java:129)
    at com.ocpsoft.rewrite.servlet.impl.HttpInboundRewriteImpl.encodeRedirectUrl(HttpInboundRewriteImpl.java:149)
    at com.ocpsoft.rewrite.servlet.impl.HttpInboundRewriteImpl.redirect(HttpInboundRewriteImpl.java:132)
    at com.ocpsoft.rewrite.servlet.impl.HttpInboundRewriteImpl.redirectTemporary(HttpInboundRewriteImpl.java:47)
    at com.ocpsoft.rewrite.servlet.config.Redirect.performHttp(Redirect.java:63)
    at com.ocpsoft.rewrite.servlet.config.HttpOperation.perform(HttpOperation.java:42)
    at com.ocpsoft.rewrite.config.RuleBuilder.perform(RuleBuilder.java:84)
    at com.ocpsoft.rewrite.servlet.impl.DefaultHttpRewriteProvider.rewrite(DefaultHttpRewriteProvider.java:50)
    at com.ocpsoft.rewrite.servlet.impl.DefaultHttpRewriteProvider.rewrite(DefaultHttpRewriteProvider.java:1)
    at com.ocpsoft.rewrite.servlet.RewriteFilter.rewrite(RewriteFilter.java:180)
    at com.ocpsoft.rewrite.servlet.RewriteFilter.doFilter(RewriteFilter.java:144)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:243)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:210)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:224)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:175)
    at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:472)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:164)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:100)
    at org.apache.catalina.valves.AccessLogValve.invoke(AccessLogValve.java:929)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:118)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:405)
    at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:279)
    at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:515)
    at org.apache.tomcat.util.net.JIoEndpoint$SocketProcessor.run(JIoEndpoint.java:300)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
    at java.lang.Thread.run(Thread.java:662)
```

Another option would be to simply save an empty list for the parameter instead of a list with one null value. Perhaps this would be nicer?
