### PR TITLE
Set scope of API dependencies to provided

### DIFF
--- a/integration-cdi/pom.xml
+++ b/integration-cdi/pom.xml
@@ -37,10 +37,12 @@
       <dependency>
          <groupId>org.jboss.spec.javax.servlet</groupId>
          <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+         <scope>provided</scope>
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.el</groupId>
          <artifactId>jboss-el-api_2.2_spec</artifactId>
+         <scope>provided</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The CDI integration module declares some API dependencies with compile scope. This totally breaks deployment at least on Tomcat7 (LinkageError). This fixes the issue for me! :)
