### PR TITLE
CdiServiceLocator now works correctly

### DIFF
--- a/integration-cdi/src/main/java/com/ocpsoft/rewrite/cdi/CdiServiceLocator.java
+++ b/integration-cdi/src/main/java/com/ocpsoft/rewrite/cdi/CdiServiceLocator.java
@@ -29,15 +29,13 @@ import javax.enterprise.util.AnnotationLiteral;
 import org.jboss.solder.beanManager.BeanManagerAware;
 
 import com.ocpsoft.common.spi.ServiceLocator;
-import com.ocpsoft.logging.Logger;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
- * 
+ * @author <a href="mailto:christian@kaltepoth.de">Christian Kaltepoth</a>
  */
 public class CdiServiceLocator extends BeanManagerAware implements ServiceLocator
 {
-   Logger log = Logger.getLogger(CdiServiceLocator.class);
 
    @Override
    @SuppressWarnings("unchecked")
@@ -45,17 +43,23 @@ public class CdiServiceLocator extends BeanManagerAware implements ServiceLocato
    {
       List<Class<T>> result = new ArrayList<Class<T>>();
 
-      BeanManager manager = getBeanManager();
+      // the BeanManager may be not available during Rewrite startup
+      if (isBeanManagerAvailable()) {
 
-      Set<Bean<?>> beans = manager.getBeans(type, new Annotation[] { new AnnotationLiteral<Any>() {
-         private static final long serialVersionUID = -1896831901770051851L;
-      } });
+         BeanManager manager = getBeanManager();
 
-      for (Bean<?> bean : beans) {
-         result.add((Class<T>) bean.getBeanClass());
+         Set<Bean<?>> beans = manager.getBeans(type, new Annotation[] { new AnnotationLiteral<Any>() {
+            private static final long serialVersionUID = -1896831901770051851L;
+         } });
+
+         for (Bean<?> bean : beans) {
+            result.add((Class<T>) bean.getBeanClass());
+         }
+
       }
 
       return result;
+
    }
 
 }

--- a/integration-cdi/src/main/resources/META-INF/services/com.ocpsoft.common.spi.ServiceLocator
+++ b/integration-cdi/src/main/resources/META-INF/services/com.ocpsoft.common.spi.ServiceLocator
@@ -1,0 +1,1 @@
+com.ocpsoft.rewrite.cdi.CdiServiceLocator

--- a/integration-cdi/src/test/java/com/ocpsoft/rewrite/cdi/bridge/CdiMultipleFeaturesTest.java
+++ b/integration-cdi/src/test/java/com/ocpsoft/rewrite/cdi/bridge/CdiMultipleFeaturesTest.java
@@ -20,7 +20,6 @@ import junit.framework.Assert;
 import org.apache.http.client.methods.HttpGet;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,13 +41,8 @@ public class CdiMultipleFeaturesTest extends RewriteTestBase
    @Deployment(testable = true)
    public static WebArchive getDeployment()
    {
-      WebArchive deployment = RewriteTestBase.getDeployment()
-               .addPackages(true, CDIRoot.class.getPackage())
-               .addAsResource(new StringAsset("com.ocpsoft.rewrite.cdi.bridge.ServiceEnricherTestConfigProvider\n" +
-                        "com.ocpsoft.rewrite.cdi.bind.ExpressionLanguageTestConfigurationProvider"),
-                        "/META-INF/services/com.ocpsoft.rewrite.config.ConfigurationProvider");
-
-      return deployment;
+      return RewriteTestBase.getDeployment()
+               .addPackages(true, CDIRoot.class.getPackage());
    }
 
    /*


### PR DESCRIPTION
Hey Lincoln,

the CdiServiceLocator now works correctly. You already started to implement it but the entry in the META-INF/services directory was missing. I added the services entry and after that my application crashed with some strange endless loop. I digged into this and it was caused by the logger you included in the class. The creation of the logger was itself using the ServiceLocator which then created CdiServiceLocator again and so on. This is fixed now and the CdiServiceLocator is working fine.

Christian
