### PR TITLE
Allow ElProperty binding during the JSF lifecycle (also while CDI contexts are active).

### DIFF
--- a/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/DeferredRewriteProvider.java
+++ b/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/DeferredRewriteProvider.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.ocpsoft.rewrite.faces;
+
+import com.ocpsoft.rewrite.config.Configuration;
+import com.ocpsoft.rewrite.config.ConfigurationLoader;
+import com.ocpsoft.rewrite.config.Operation;
+import com.ocpsoft.rewrite.config.Rule;
+import com.ocpsoft.rewrite.faces.config.DeferredOperation;
+import com.ocpsoft.rewrite.servlet.event.BaseRewrite.Flow;
+import com.ocpsoft.rewrite.servlet.http.HttpRewriteProvider;
+import com.ocpsoft.rewrite.servlet.http.event.HttpServletRewrite;
+import com.ocpsoft.rewrite.servlet.impl.EvaluationContextImpl;
+
+/**
+ * @author <a href="mailto:fabmars@gmail.com">Fabien Marsaud</a>
+ */
+public class DeferredRewriteProvider extends HttpRewriteProvider
+{
+
+   @Override
+   public void rewrite(HttpServletRewrite event)
+   {
+      Configuration loader = ConfigurationLoader.loadConfiguration(event.getRequest().getServletContext());
+      for (Rule rule : loader.getRules()) {
+         EvaluationContextImpl context = new EvaluationContextImpl();
+         if (rule.evaluate(event, context))
+         {
+            for (Operation operation : context.getPreOperations()) //which should be binding operations
+            {
+               operation = new DeferredOperation(event, context, operation);
+               operation.perform(event, context);
+            }
+
+            if (event.getFlow().is(Flow.HANDLED))
+            {
+               break;
+            }
+
+            rule.perform(event, context);
+
+            if (event.getFlow().is(Flow.HANDLED))
+            {
+               break;
+            }
+
+            for (Operation operation : context.getPostOperations()) {
+               operation = new DeferredOperation(event, context, operation);
+               operation.perform(event, context);
+            }
+
+            if (event.getFlow().is(Flow.HANDLED))
+            {
+               break;
+            }
+         }
+      }
+   }
+
+   @Override
+   public int priority()
+   {
+      return -1;
+   }
+
+}

--- a/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/config/DeferredOperation.java
+++ b/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/config/DeferredOperation.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.ocpsoft.rewrite.faces.config;
+
+import javax.faces.event.PhaseId;
+
+import com.ocpsoft.rewrite.config.Operation;
+import com.ocpsoft.rewrite.context.EvaluationContext;
+import com.ocpsoft.rewrite.event.Rewrite;
+import com.ocpsoft.rewrite.servlet.http.event.HttpServletRewrite;
+
+/**
+ * This class encapsulates another operation that should be performed during the JSF lifecycle
+ * 
+ * @author <a href="mailto:fabmars@gmail.com">Fabien Marsaud</a>
+ */
+public class DeferredOperation implements Operation
+{
+   private final HttpServletRewrite event;
+   private final EvaluationContext context;
+   private final Operation pendingOperation;
+   private final PhaseId beforePhase;
+   private final PhaseId afterPhase;
+   private boolean consumed;
+
+   public DeferredOperation(final HttpServletRewrite event, final EvaluationContext context, final Operation operation)
+   {
+      this.event = event;
+      this.context = context;
+      this.pendingOperation = operation;
+      
+      if (pendingOperation instanceof PhaseBinding) {
+         PhaseBinding phaseBinding = (PhaseBinding) pendingOperation;
+         this.beforePhase = phaseBinding.getBeforePhase();
+         this.afterPhase = phaseBinding.getAfterPhase();
+      }
+      else
+      {
+         this.beforePhase = null;
+         this.afterPhase = PhaseId.RESTORE_VIEW;
+      }
+   }
+   
+   public Operation getPendingOperation()
+   {
+      return pendingOperation;
+   }
+
+   public PhaseId getBeforePhase()
+   {
+      return beforePhase;
+   }
+
+   public PhaseId getAfterPhase()
+   {
+      return afterPhase;
+   }
+
+   public boolean isConsumed()
+   {
+      return consumed;
+   }
+
+   /**
+    * Invoked during the rewrite process, just add "this" to a queue of deferred bindings in the request
+    */
+   @Override
+   public void perform(Rewrite event, EvaluationContext context)
+   {
+      PhaseBinding.getDeferredOperations(this.event.getRequest()).add(this);
+   }
+   
+   /**
+    * Invokes the nested pending operation
+    */
+   public void performDeferredOperation()
+   {
+      consumed = true;
+      pendingOperation.perform(event, context);
+   }
+}
+
+

--- a/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/config/PhaseBinding.java
+++ b/integration-faces/src/main/java/com/ocpsoft/rewrite/faces/config/PhaseBinding.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.ocpsoft.rewrite.faces.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.faces.event.PhaseId;
+import javax.servlet.http.HttpServletRequest;
+
+import com.ocpsoft.logging.Logger;
+import com.ocpsoft.rewrite.bind.Binding;
+import com.ocpsoft.rewrite.bind.El.ElProperty;
+import com.ocpsoft.rewrite.context.EvaluationContext;
+import com.ocpsoft.rewrite.event.Rewrite;
+
+/**
+ * Wraps & holds a param binding till before or after a given JavaServer Faces {@link PhaseId}
+ * 
+ * @author <a href="mailto:fabmars@gmail.com">Fabien Marsaud</a>
+ */
+public class PhaseBinding implements Binding
+{
+   private static final String DEFERRED_OPERATIONS = PhaseBinding.class + "_QUEUED";
+   private static final Logger log = Logger.getLogger(PhaseBinding.class);
+   
+   private final Binding binding;
+   private PhaseId beforePhase; //it's wrong to perform the binding before PhaseId.RESTORE_VIEW
+   private PhaseId afterPhase; //it's useless to perform the binding after PhaseId.RENDER_RESPONSE
+
+
+   private PhaseBinding(Binding binding)
+   {
+      if (binding == null)
+      {
+         throw new NullPointerException("binding");
+      }
+      else if (!(binding instanceof ElProperty))
+      {
+         log.warn("binding ought to be an ElProperty; instead it is a [" + binding.getClass().getName() + "].");
+      }
+      this.binding = binding;
+   }
+   
+   /**
+    * Wraps the Binding into a new PhaseInjection, so as to have it performed duriung the JSF lifecycle 
+    * By default, the original binding will be performed after {@link PhaseId#RESTORE_VIEW}
+    */
+   public static PhaseBinding withhold(final Binding binding)
+   {
+      return (PhaseBinding) new PhaseBinding(binding).tillAfter(PhaseId.RESTORE_VIEW);
+   }
+
+   public PhaseId getBeforePhase()
+   {
+      return beforePhase;
+   }
+
+   public PhaseId getAfterPhase()
+   {
+      return afterPhase;
+   }
+
+   public Binding tillBefore(final PhaseId phase)
+   {
+      this.beforePhase = phase;
+      return this;
+   }
+
+   public Binding tillAfter(final PhaseId phase)
+   {
+      this.afterPhase = phase;
+      return this;
+   }
+
+   @Override
+   public Object retrieve(Rewrite event, EvaluationContext context)
+   {
+      return null;
+   }
+
+   @Override
+   public Object convert(Rewrite event, EvaluationContext context, Object value)
+   {
+      return binding.convert(event, context, value);
+   }
+
+   @Override
+   public boolean validates(Rewrite event, EvaluationContext context, Object value)
+   {
+      return binding.validates(event, context, value);
+   }
+
+   @Override
+   public Object submit(Rewrite event, EvaluationContext context, Object value)
+   {
+      return binding.submit(event, context, value);
+   }
+
+   @Override
+   public boolean supportsRetrieval()
+   {
+      return false;
+   }
+
+   @Override
+   public boolean supportsSubmission()
+   {
+      return true;
+   }
+   
+   @SuppressWarnings("unchecked")
+   public static List<DeferredOperation> getDeferredOperations(final HttpServletRequest request)
+   {
+      List<DeferredOperation> operations = (List<DeferredOperation>) request.getAttribute(DEFERRED_OPERATIONS);
+      if (operations == null)
+      {
+         operations = new ArrayList<DeferredOperation>();
+         request.setAttribute(DEFERRED_OPERATIONS, operations);
+      }
+      return operations;
+   }
+
+   public static void removeDefferredOperations(final HttpServletRequest request)
+   {
+      request.removeAttribute(DEFERRED_OPERATIONS);
+   }
+}

--- a/integration-faces/src/main/resources/META-INF/services/com.ocpsoft.rewrite.spi.RewriteProvider
+++ b/integration-faces/src/main/resources/META-INF/services/com.ocpsoft.rewrite.spi.RewriteProvider
@@ -1,0 +1,1 @@
+com.ocpsoft.rewrite.faces.DeferredRewriteProvider


### PR DESCRIPTION
Short explanation: after I hacked PhaseBinding with an usage close to this of PhaseAction, I thought that was counter intuitive, and I decided to add an extra RewriteProvider within integration-faces with a lower priority than the http one, where operations are encapsulated within DeferredOperation instances and stacked in the request. RewritePhaseListener is modified to unwrap and trigger perform during the right phase. Tested with a sample project.

Usage: either wrap the binding using PhaseBinding#withhold, and it's
also possible to decide in which jsf phase the binding will be
eventually performed with #tillBefore or #tillAfter
Example config: ConfigurationBuilder.begin()
.addRule(Join.path("/blog/entry/{id}/").to("/blogView.jsf").where("id").bindsTo(PhaseBinding.withhold(El.property("blogEntryHandler.id")).tillBefore(PhaseId.INVOKE_APPLICATION)))

or directly use the BindingBuilder and the phase will be RESTORE_VIEW /
After
Example config: ConfigurationBuilder.begin()
.addRule(Join.path("/article/id/{id}/").to("/articleView.jsf").where("id").bindsTo(El.property("articleHandler.id")))
