### PR TITLE
Fixed /META-INF/services entries for config-annotations-impl

### DIFF
--- a/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.annotation.spi.AnnotationHandler
+++ b/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.annotation.spi.AnnotationHandler
@@ -1,4 +1,0 @@
-org.ocpsoft.prettyfaces.annotation.handlers.ForwardToHandler
-org.ocpsoft.prettyfaces.annotation.handlers.JSFValidatorHandler
-org.ocpsoft.prettyfaces.annotation.handlers.NamedParameterHandler
-org.ocpsoft.prettyfaces.annotation.handlers.URLPatternHandler

--- a/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.AnnotationConfigurationProvider
+++ b/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.AnnotationConfigurationProvider
@@ -1,1 +1,0 @@
-org.ocpsoft.prettyfaces.annotation.AnnotationConfigProvider

--- a/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.ConfigurationProvider
+++ b/config-annotations-impl/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.ConfigurationProvider
@@ -1,0 +1,1 @@
+org.ocpsoft.rewrite.annotation.AnnotationConfigProvider


### PR DESCRIPTION
Hey Lincoln,

there are currently invalid "/META-INF/services" entries in the config-annotations-impl module. Seems like they where copied from the PrettyFaces 4.x code.

Christian
