### PR TITLE
Changed the order in which AnnotatedElements are processed by handlers

### DIFF
--- a/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/ClassVisitorImpl.java
+++ b/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/ClassVisitorImpl.java
@@ -72,18 +72,18 @@ public class ClassVisitorImpl implements ClassVisitor, Configuration
          log.trace("Scanning class: {}", clazz.getName());
       }
 
-      // first process fields
+      // first process the class
+      visit(clazz, context);
+
+      // then process the fields
       for (Field field : clazz.getDeclaredFields()) {
          visit(field, context);
       }
 
-      // the methods
+      // finally the methods
       for (Method method : clazz.getDeclaredMethods()) {
          visit(method, context);
       }
-
-      // the class itself is last
-      visit(clazz, context);
 
    }
 


### PR DESCRIPTION
Now as the MappingBuilder has been removed and we are directly using the RuleBuilder from the annotation handlers I think it makes sense to change the order in which AnnotatedElements are processed by the handlers. 

Currently fields and methods are processed BEFORE the class itself is processed. This patch changes this so that the class is processed first and the fields and method after that.

This change is required for the PrettyFaces 4.0 annotation handlers I'm currently prototyping.
