### PR TITLE
Added visitor support for conditions

### DIFF
--- a/api/src/main/java/org/ocpsoft/rewrite/config/ConditionVisit.java
+++ b/api/src/main/java/org/ocpsoft/rewrite/config/ConditionVisit.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.config;
+
+/**
+ * This class allows {@link Visitor}s to walk through a {@link Condition} tree which may contain
+ * {@link CompositeCondition} elements.
+ * 
+ * @author Christian Kaltepoth
+ */
+public class ConditionVisit
+{
+
+   private final Condition root;
+
+   /**
+    * Initialize class with the supplied root {@link Condition}
+    */
+   public ConditionVisit(Condition root)
+   {
+      this.root = root;
+   }
+
+   /**
+    * Submit the supplied visitor and apply it to all conditions in the tree
+    */
+   public void accept(Visitor<Condition> visitor)
+   {
+      visit(root, visitor);
+   }
+
+   /**
+    * Method to call the visitor for the supplied condition and recursively calls itself, if the condition is a
+    * {@link CompositeCondition}.
+    */
+   private void visit(Condition condition, Visitor<Condition> visitor)
+   {
+
+      // visit the condition itself
+      visitor.visit(condition);
+
+      // recursive call for all children if a CompositeCondition
+      if (condition instanceof CompositeCondition) {
+         for (Condition child : ((CompositeCondition) condition).getConditions()) {
+            visit(child, visitor);
+         }
+      }
+   }
+
+}

--- a/api/src/main/java/org/ocpsoft/rewrite/config/RuleBuilder.java
+++ b/api/src/main/java/org/ocpsoft/rewrite/config/RuleBuilder.java
@@ -145,4 +145,15 @@ public class RuleBuilder implements RelocatableRule
 
       return (DefaultOperationBuilder) operation;
    }
+
+   /**
+    * This method will call the supplied visitor for all conditions attached to the rule builder.
+    * 
+    * @param visitor visitor to process
+    */
+   public void accept(Visitor<Condition> visitor)
+   {
+      new ConditionVisit(condition).accept(visitor);
+   }
+
 }

--- a/api/src/main/java/org/ocpsoft/rewrite/config/Visitor.java
+++ b/api/src/main/java/org/ocpsoft/rewrite/config/Visitor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.config;
+
+/**
+ * General purpose visitor interface
+ * 
+ * @author Christian Kaltepoth
+ */
+public interface Visitor<E>
+{
+
+   /**
+    * Visit the supplied object
+    */
+   void visit(E e);
+
+}

--- a/api/src/test/java/org/ocpsoft/rewrite/config/ConditionVisitTest.java
+++ b/api/src/test/java/org/ocpsoft/rewrite/config/ConditionVisitTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class ConditionVisitTest
+{
+
+   @Test
+   public void testConditionVisit()
+   {
+
+      // setup condition tree
+      Condition condition1 = new True();
+      Condition condition2 = new True();
+      Condition condition3 = new True();
+      Condition root = And.all(condition1, Or.any(condition2, condition3));
+
+      // set of visited conditions for verification
+      final Set<Condition> visited = new HashSet<Condition>();
+
+      // visit the tree
+      new ConditionVisit(root).accept(new Visitor<Condition>() {
+         @Override
+         public void visit(Condition e)
+         {
+            visited.add(e);
+         }
+      });
+
+      // all 5 conditions should have been visited (3x True, 1x And, 1x Or)
+      assertEquals(5, visited.size());
+
+   }
+
+}


### PR DESCRIPTION
I created a patch for the visitor support we talked about for walking through the condition tree.

It's working fine for my prototype for a `@ParameterBinding` annotation. It uses such a visitor for adding bindings to all conditions implementing `Parameterized`.

wdyt?
