### PR TITLE
Fixed NPE that appears when running Arquillian tests on embedded Jetty

### DIFF
--- a/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/WebClassesFinder.java
+++ b/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/WebClassesFinder.java
@@ -118,6 +118,12 @@ public class WebClassesFinder extends AbstractClassFinder
             // get full URL for this entry
             URL entryUrl = servletContext.getResource(relativePath.toString());
 
+            // Embedded Jetty bug?
+            if (entryUrl == null) {
+               log.warn("Unable to obtain URL for relative path: " + relativePath.toString());
+               continue;
+            }
+
             // if this URL ends with .class it is a Java class
             if (entryUrl.getPath().endsWith(".class"))
             {


### PR DESCRIPTION
There seems to be a NPE issue when running the annotation scanning code on embedded Jetty. This patch fixes this.
