### PR TITLE
Integration test for FacesExpressionLanguageProvider

### DIFF
--- a/integration-faces/pom.xml
+++ b/integration-faces/pom.xml
@@ -44,7 +44,11 @@
 			<artifactId>javax.faces</artifactId>
 			<version>2.1.7</version>
 		</dependency>
-
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>jstl</artifactId>
+			<version>1.1.2</version>
+		</dependency>
 		<dependency>
 			<groupId>org.ocpsoft.rewrite</groupId>
 			<artifactId>rewrite-test-harness</artifactId>

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageBean.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageBean.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.el;
+
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.RequestScoped;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@ManagedBean
+@RequestScoped
+public class ExpressionLanguageBean
+{
+
+   private String name;
+
+   private String uppercase;
+
+   public void action()
+   {
+      uppercase = name != null ? name.toUpperCase() : null;
+   }
+
+   public String getName()
+   {
+      return name;
+   }
+
+   public void setName(String name)
+   {
+      this.name = name;
+   }
+
+   public String getUppercase()
+   {
+      return uppercase;
+   }
+
+   public void setUppercase(String uppercase)
+   {
+      this.uppercase = uppercase;
+   }
+
+}

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageConfigProvider.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageConfigProvider.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.el;
+
+import javax.faces.event.PhaseId;
+import javax.servlet.ServletContext;
+
+import org.ocpsoft.rewrite.bind.El;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.faces.config.PhaseAction;
+import org.ocpsoft.rewrite.faces.config.PhaseBinding;
+import org.ocpsoft.rewrite.servlet.config.Forward;
+import org.ocpsoft.rewrite.servlet.config.HttpConfigurationProvider;
+import org.ocpsoft.rewrite.servlet.config.Path;
+
+/**
+ * @author Christian Kaltepoth
+ */
+public class ExpressionLanguageConfigProvider extends HttpConfigurationProvider
+{
+
+   @Override
+   public Configuration getConfiguration(final ServletContext context)
+   {
+      return ConfigurationBuilder
+               .begin()
+               .defineRule()
+               .when(Path
+                        .matches("/name/{name}")
+                        .where("name")
+                        .bindsTo(PhaseBinding.to(El.property("#{expressionLanguageBean.name}"))
+                                 .after(PhaseId.RESTORE_VIEW)))
+               .perform(PhaseAction.retrieveFrom(El.retrievalMethod("#{expressionLanguageBean.action}"))
+                        .after(PhaseId.RESTORE_VIEW)
+                        .and(Forward.to("/faces/expression-language.xhtml")));
+   }
+
+   @Override
+   public int priority()
+   {
+      return 0;
+   }
+
+}

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageTest.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/el/ExpressionLanguageTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.el;
+
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.ConfigurationProvider;
+import org.ocpsoft.rewrite.test.HttpAction;
+import org.ocpsoft.rewrite.test.RewriteTestBase;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@RunWith(Arquillian.class)
+public class ExpressionLanguageTest extends RewriteTestBase
+{
+
+   @Deployment(testable = false)
+   public static WebArchive getDeployment()
+   {
+      return ShrinkWrap
+               .create(WebArchive.class, "rewrite-test.war")
+               .addAsLibraries(getRewriteArchive())
+               .setWebXML("faces-web.xml")
+               .addAsLibraries(resolveDependencies("org.glassfish:javax.faces:jar:2.1.7"))
+               .addAsWebInfResource("faces-config.xml", "faces-config.xml")
+               .addAsWebResource("expression-language.xhtml")
+               .addPackages(true, ExpressionLanguageBean.class.getPackage())
+               .addAsServiceProvider(ConfigurationProvider.class, ExpressionLanguageConfigProvider.class);
+   }
+
+   @Test
+   public void testSpringFeatures()
+   {
+      HttpAction<HttpGet> action = get("/name/christian");
+      String content = action.getResponseContent();
+      Assert.assertTrue(content.contains("Name = [christian]"));
+      Assert.assertTrue(content.contains("Uppercase = [CHRISTIAN]"));
+   }
+
+}

--- a/integration-faces/src/test/resources/expression-language.xhtml
+++ b/integration-faces/src/test/resources/expression-language.xhtml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:ui="http://java.sun.com/jsf/facelets">
+	
+  <p>Name = [#{expressionLanguageBean.name}]</p>
+
+  <p>Uppercase = [#{expressionLanguageBean.uppercase}]</p>
+	
+</html>
+


### PR DESCRIPTION
Hey Lincoln,

I added the integration test for the new `FacesExpressionLanguageProvider` we talked about. Works fine.

However I'm also seeing a strange exception here in the logs although the test works fine:

```
INFO: RewriteFilter initialized.
10.04.2012 07:25:39 org.eclipse.jetty.util.log.Slf4jLog info
INFO: WebApp@1589782904 at http://localhost:9090/rewrite-test
log4j:WARN No appenders could be found for logger (org.apache.http.impl.conn.SingleClientConnManager).
log4j:WARN Please initialize the log4j system properly.
10.04.2012 07:25:40 org.eclipse.jetty.util.log.Slf4jLog warn
WARNUNG: Committed before 404 null
10.04.2012 07:25:40 org.eclipse.jetty.util.log.Slf4jLog warn
WARNUNG: /rewrite-test/name/christian
java.lang.IllegalStateException: Committed
    at org.eclipse.jetty.server.Response.resetBuffer(Response.java:1066)
    at org.eclipse.jetty.server.Response.sendError(Response.java:274)
    at org.eclipse.jetty.server.Response.sendError(Response.java:376)
    at javax.servlet.http.HttpServletResponseWrapper.sendError(HttpServletResponseWrapper.java:162)
    at org.eclipse.jetty.servlet.DefaultServlet.doGet(DefaultServlet.java:472)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:734)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:847)
    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:550)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1359)
    at org.ocpsoft.rewrite.servlet.RewriteFilter.doFilter(RewriteFilter.java:183)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1330)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:484)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:119)
    at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:517)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:233)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:970)
    at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:414)
    at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:192)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:904)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:117)
    at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:149)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:110)
    at org.eclipse.jetty.server.Server.handle(Server.java:347)
    at org.eclipse.jetty.server.HttpConnection.handleRequest(HttpConnection.java:439)
    at org.eclipse.jetty.server.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:907)
    at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:562)
    at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:214)
    at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:43)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:545)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:43)
    at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:529)
    at java.lang.Thread.run(Thread.java:679)
10.04.2012 07:25:40 org.ocpsoft.logging.slf4j.SLF4JLogAdapter log
INFO: RewriteFilter shutting down...
```

Any idea?
