### PR TITLE
Created new FieldContext for annotation handlers processing fields

### DIFF
--- a/config-annotations-api/src/main/java/org/ocpsoft/rewrite/annotation/api/FieldContext.java
+++ b/config-annotations-api/src/main/java/org/ocpsoft/rewrite/annotation/api/FieldContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.annotation.api;
+
+import org.ocpsoft.rewrite.bind.BindingBuilder;
+
+/**
+ * Context for scanning a single field of a class
+ * 
+ * @author Christian Kaltepoth
+ */
+@SuppressWarnings("rawtypes")
+public interface FieldContext extends ClassContext
+{
+
+   /**
+    * Sets the {@link BindingBuilder} for the current field. Should be called by annotation handlers after they created
+    * a binding for the field.
+    */
+   public void setBindingBuilder(BindingBuilder bindingBuilder);
+
+   /**
+    * Returns the {@link BindingBuilder} for the current field. May return <code>null</code> if no binding has been
+    * created for the field yet.
+    */
+   public BindingBuilder getBindingBuilder();
+
+}

--- a/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/ClassVisitorImpl.java
+++ b/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/ClassVisitorImpl.java
@@ -13,6 +13,7 @@ import org.ocpsoft.logging.Logger;
 import org.ocpsoft.rewrite.annotation.api.ClassContext;
 import org.ocpsoft.rewrite.annotation.api.ClassVisitor;
 import org.ocpsoft.rewrite.annotation.scan.ClassContextImpl;
+import org.ocpsoft.rewrite.annotation.scan.FieldContextImpl;
 import org.ocpsoft.rewrite.annotation.spi.AnnotationHandler;
 import org.ocpsoft.rewrite.config.Configuration;
 import org.ocpsoft.rewrite.config.ConfigurationBuilder;
@@ -77,7 +78,7 @@ public class ClassVisitorImpl implements ClassVisitor, Configuration
 
       // then process the fields
       for (Field field : clazz.getDeclaredFields()) {
-         visit(field, context);
+         visit(field, new FieldContextImpl(context));
       }
 
       // finally the methods

--- a/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/FieldContextImpl.java
+++ b/config-annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/FieldContextImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.annotation.scan;
+
+import org.ocpsoft.rewrite.annotation.api.ClassContext;
+import org.ocpsoft.rewrite.annotation.api.FieldContext;
+import org.ocpsoft.rewrite.bind.BindingBuilder;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.config.RuleBuilder;
+import org.ocpsoft.rewrite.context.ContextBase;
+
+/**
+ * Default implementation of {@link FieldContext}
+ * 
+ * @author Christian Kaltepoth
+ */
+@SuppressWarnings("rawtypes")
+public class FieldContextImpl extends ContextBase implements FieldContext
+{
+
+   private final ClassContext classContext;
+
+   private BindingBuilder bindingBuilder;
+
+   public FieldContextImpl(ClassContext classContext)
+   {
+      this.classContext = classContext;
+   }
+
+   @Override
+   public ConfigurationBuilder getConfigurationBuilder()
+   {
+      return classContext.getConfigurationBuilder();
+   }
+
+   @Override
+   public RuleBuilder getRuleBuilder()
+   {
+      return classContext.getRuleBuilder();
+   }
+
+   @Override
+   public void setBindingBuilder(BindingBuilder bindingBuilder)
+   {
+      this.bindingBuilder = bindingBuilder;
+   }
+
+   @Override
+   public BindingBuilder getBindingBuilder()
+   {
+      return bindingBuilder;
+   }
+
+}


### PR DESCRIPTION
Hey Lincoln,

I'm currently finishing the implementation of some of the annotation handlers. During working on this I noticed that it would make sense to have some kind of field context object that is able to hold information that affects only the field currently processed by the handlers. IMHO this makes sense because the annotations placed on a single field typically process some "entity" (like a binding for example) and therefore need to share some information.

This pull request contains a new context called `FieldContext` which extends `ClassContext`. This context currently only provides the possibility to register a "current binding" (`@ParameterBinding` does this) and to retrieve it (which other handles could to to enrich the binding).

I already modified two of the annotation handlers to use this new field context. The `ParameterBindingHandler` registers the just created binding:

https://github.com/chkal/prettyfaces/blob/field-context/annotations/src/main/java/org/ocpsoft/prettyfaces/annotation/handlers/ParameterBindingHandler.java#L93

And the `JSFValidatorHandler` retrieves this binding to attach a validator:

https://github.com/chkal/prettyfaces/blob/field-context/annotations/src/main/java/org/ocpsoft/prettyfaces/annotation/handlers/JSFValidatorHandler.java#L44

Works fine! :)

What do you think?
