### PR TITLE
Updated Arquillian to 1.0.0.Final

### DIFF
--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/PhaseOperationTest.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/PhaseOperationTest.java
@@ -22,12 +22,13 @@ import org.apache.http.client.methods.HttpGet;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.descriptor.impl.base.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteTestBase;
+
+import com.google.common.base.Strings;
 
 /**
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -12,8 +12,9 @@
    <artifactId>rewrite-test-harness</artifactId>
 
    <properties>
-      <version.arquillian>1.0.0.CR1</version.arquillian>
-      <version.jetty>8.0.0.RC0</version.jetty>
+      <version.arquillian>1.0.0.Final</version.arquillian>
+      <version.arquillian.jetty>1.0.0.CR1</version.arquillian.jetty>
+      <version.jetty>8.1.2.v20120308</version.jetty>
    </properties>
 
    <dependencies>
@@ -60,7 +61,19 @@
             <dependency>
                <groupId>org.jboss.arquillian.container</groupId>
                <artifactId>arquillian-jetty-embedded-7</artifactId>
-               <version>${version.arquillian}</version>
+               <version>${version.arquillian.jetty}</version>
+               <exclusions>
+                  <!-- Don't include the old version of arquillian-container-spi -->
+                  <exclusion>
+                     <groupId>org.jboss.arquillian.container</groupId>
+                     <artifactId>arquillian-container-spi</artifactId>
+                  </exclusion>
+               </exclusions>
+            </dependency>
+            <dependency>
+               <groupId>org.jboss.shrinkwrap.resolver</groupId>
+               <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+               <version>1.0.0-beta-6</version>
             </dependency>
             <dependency>
                <groupId>org.eclipse.jetty</groupId>
@@ -72,13 +85,25 @@
                <artifactId>jetty-plus</artifactId>
                <version>${version.jetty}</version>
             </dependency>
+            <dependency>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-simple</artifactId>
+               <version>1.5.10</version>
+            </dependency>
 
             <!-- Weld servlet, EL and JSP required for testing CDI injections -->
+            <!-- Don't use 'org.jboss.weld.servlet:weld-servlet' as it has an incompatible slf4j version shaded in -->
             <dependency>
                <groupId>org.jboss.weld.servlet</groupId>
-               <artifactId>weld-servlet</artifactId>
+               <artifactId>weld-servlet-core</artifactId>
                <version>1.1.4.Final</version>
             </dependency>
+            <dependency>
+               <groupId>org.jboss.weld</groupId>
+               <artifactId>weld-core</artifactId>
+               <version>1.1.4.Final</version>
+            </dependency>
+
             <dependency>
                <groupId>javax.enterprise</groupId>
                <artifactId>cdi-api</artifactId>


### PR DESCRIPTION
Hey Lincoln,

I was searching for the reason of the "response already committed" exception I got in the integration tests. Therefore I updated Arquillian to 1.0.0.Final and Jetty to the latest 8.1 release. Unfortunately I'm still getting the exception.

However I think we could consider to do these updates. All tests are running fine. The only problem I got was that running the build failed due to "too many open files" exceptions. But after increasing the allowed number of open files via `/etc/security/limits.conf` from 1024 to 2048 everything works fine.

I'm not sure if we should apply this patch due to the file limit problem. I leave it to you. Perhaps it is a problem that only appears on my box? I'm not sure. :)
