### PR TITLE
JSF implementation of BeanNameResolver

### DIFF
--- a/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/FacesBeanNameResolver.java
+++ b/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/FacesBeanNameResolver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces;
+
+import javax.faces.bean.ManagedBean;
+
+import org.ocpsoft.rewrite.el.spi.BeanNameResolver;
+
+/**
+ * Implementation of {@link BeanNameResolver} that checks for {@link ManagedBean} annotations on the class.
+ * 
+ * @author Christian Kaltepoth
+ */
+public class FacesBeanNameResolver implements BeanNameResolver
+{
+
+   @Override
+   public String getBeanName(Class<?> clazz)
+   {
+      ManagedBean annotation = clazz.getAnnotation(ManagedBean.class);
+      if (annotation != null) {
+
+         // name is set using the annotation
+         if (annotation.name().length() > 0) {
+            return annotation.name();
+         }
+
+         // no name, so name is auto generated
+         else {
+            String className = clazz.getSimpleName();
+            return Character.toLowerCase(className.charAt(0)) + className.substring(1);
+         }
+
+      }
+
+      // no @ManagedBean annotation -> not a JSF bean
+      return null;
+
+   }
+
+}

--- a/integration-faces/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.ConfigurationProvider
+++ b/integration-faces/src/main/resources/META-INF/services/org.ocpsoft.rewrite.config.ConfigurationProvider
@@ -1,0 +1,1 @@
+org.ocpsoft.rewrite.faces.resolver.FacesBeanNameResolverConfigProvider

--- a/integration-faces/src/main/resources/META-INF/services/org.ocpsoft.rewrite.el.spi.BeanNameResolver
+++ b/integration-faces/src/main/resources/META-INF/services/org.ocpsoft.rewrite.el.spi.BeanNameResolver
@@ -1,0 +1,1 @@
+org.ocpsoft.rewrite.faces.FacesBeanNameResolver

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverBean.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverBean.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.resolver;
+
+import javax.faces.bean.ManagedBean;
+import javax.faces.bean.RequestScoped;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@ManagedBean
+@RequestScoped
+public class FacesBeanNameResolverBean
+{
+
+   private String name;
+
+   private String uppercase;
+
+   public void action()
+   {
+      uppercase = name != null ? name.toUpperCase() : null;
+   }
+
+   public String getName()
+   {
+      return name;
+   }
+
+   public void setName(String name)
+   {
+      this.name = name;
+   }
+
+   public String getUppercase()
+   {
+      return uppercase;
+   }
+
+   public void setUppercase(String uppercase)
+   {
+      this.uppercase = uppercase;
+   }
+
+}

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverConfigProvider.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverConfigProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.resolver;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import javax.faces.event.PhaseId;
+import javax.servlet.ServletContext;
+
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.ConfigurationBuilder;
+import org.ocpsoft.rewrite.el.El;
+import org.ocpsoft.rewrite.faces.config.PhaseAction;
+import org.ocpsoft.rewrite.faces.config.PhaseBinding;
+import org.ocpsoft.rewrite.servlet.config.Forward;
+import org.ocpsoft.rewrite.servlet.config.HttpConfigurationProvider;
+import org.ocpsoft.rewrite.servlet.config.Path;
+
+/**
+ * @author Christian Kaltepoth
+ */
+public class FacesBeanNameResolverConfigProvider extends HttpConfigurationProvider
+{
+
+   @Override
+   public Configuration getConfiguration(final ServletContext context)
+   {
+
+      try {
+
+         Field nameField = FacesBeanNameResolverBean.class.getDeclaredField("name");
+         Method actionMethod = FacesBeanNameResolverBean.class.getMethod("action");
+
+         return ConfigurationBuilder
+                  .begin()
+                  .defineRule()
+                  .when(Path.matches("/name/{name}")
+                           .where("name").bindsTo(PhaseBinding.to(El.property(nameField)).after(PhaseId.RESTORE_VIEW)))
+                  .perform(PhaseAction.retrieveFrom(El.retrievalMethod(actionMethod)).after(PhaseId.RESTORE_VIEW)
+                           .and(Forward.to("/faces/resolver.xhtml")));
+      }
+      catch (Exception e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   @Override
+   public int priority()
+   {
+      return 0;
+   }
+
+}

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverTest.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2011 <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.rewrite.faces.resolver;
+
+import junit.framework.Assert;
+
+import org.apache.http.client.methods.HttpGet;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.config.ConfigurationProvider;
+import org.ocpsoft.rewrite.test.HttpAction;
+import org.ocpsoft.rewrite.test.RewriteTest;
+
+/**
+ * @author Christian Kaltepoth
+ */
+@RunWith(Arquillian.class)
+public class FacesBeanNameResolverTest extends RewriteTest
+{
+
+   @Deployment(testable = false)
+   public static WebArchive getDeployment()
+   {
+      return RewriteTest
+               .getDeploymentNoWebXml()
+               .setWebXML("faces-web.xml")
+               .addAsLibraries(resolveDependencies("org.glassfish:javax.faces:jar:2.1.7"))
+               .addAsWebInfResource("faces-config.xml", "faces-config.xml")
+               .addClass(FacesBeanNameResolverBean.class)
+               .addClass(FacesBeanNameResolverConfigProvider.class)
+               .addAsServiceProvider(ConfigurationProvider.class, FacesBeanNameResolverConfigProvider.class)
+               .addAsWebResource("resolver.xhtml");
+   }
+
+   @Test
+   public void testSpringFeatures()
+   {
+      HttpAction<HttpGet> action = get("/name/christian");
+      Assert.assertEquals(200, action.getResponse().getStatusLine().getStatusCode());
+      Assert.assertTrue(action.getResponseContent().contains("Name = [christian]"));
+      Assert.assertTrue(action.getResponseContent().contains("Uppercase = [CHRISTIAN]"));
+   }
+
+}

--- a/integration-faces/src/test/resources/resolver.xhtml
+++ b/integration-faces/src/test/resources/resolver.xhtml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:ui="http://java.sun.com/jsf/facelets">
+	
+  <p>Name = [#{facesBeanNameResolverBean.name}]</p>
+
+  <p>Uppercase = [#{facesBeanNameResolverBean.uppercase}]</p>
+	
+</html>
+


### PR DESCRIPTION
This resolver detects `@ManagedBean` annotations on classes. Works fine. Integration test included. Declaring beans in `faces-config.xml` is currently not supported. But I think for now we can life with this for now.
