### PR TITLE
TypeBasedExpression now creates raw expressions without #{...}

### DIFF
--- a/api-el/src/main/java/org/ocpsoft/rewrite/el/TypeBasedExpression.java
+++ b/api-el/src/main/java/org/ocpsoft/rewrite/el/TypeBasedExpression.java
@@ -82,7 +82,7 @@ class TypeBasedExpression implements Expression
 
             // create the complete EL expression including the component
             String el = new StringBuffer()
-                     .append("#{").append(beanName).append('.').append(component).append('}')
+                     .append(beanName).append('.').append(component)
                      .toString();
 
             if (log.isTraceEnabled()) {

--- a/api-el/src/test/java/org/ocpsoft/rewrite/el/TypeBasedExpressionTest.java
+++ b/api-el/src/test/java/org/ocpsoft/rewrite/el/TypeBasedExpressionTest.java
@@ -26,7 +26,7 @@ public class TypeBasedExpressionTest
    public void testTypeBasedExpression() throws Exception
    {
       TypeBasedExpression expression = new TypeBasedExpression(BeanWithElBeanNameAnnotation.class, "sayHello");
-      assertEquals("#{myBean.sayHello}", expression.getExpression());
+      assertEquals("myBean.sayHello", expression.getExpression());
    }
 
    @ELBeanName("myBean")

--- a/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/FacesExpressionLanguageProvider.java
+++ b/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/FacesExpressionLanguageProvider.java
@@ -102,10 +102,11 @@ public class FacesExpressionLanguageProvider implements ExpressionLanguageProvid
    @Override
    public Object evaluateMethodExpression(String expression, Object... values) throws UnsupportedEvaluationException
    {
+      String el = toELExpression(expression);
       FacesContext facesContext = getFacesContext();
       ELContext elContext = facesContext.getELContext();
       ExpressionFactory expressionFactory = facesContext.getApplication().getExpressionFactory();
-      MethodExpression methodExpression = expressionFactory.createMethodExpression(elContext, expression,
+      MethodExpression methodExpression = expressionFactory.createMethodExpression(elContext, el,
                Object.class, new Class[values.length]);
       return methodExpression.invoke(elContext, values);
    }
@@ -115,8 +116,9 @@ public class FacesExpressionLanguageProvider implements ExpressionLanguageProvid
     */
    private ValueExpression getValueExpression(FacesContext facesContext, String expression)
    {
+      String el = toELExpression(expression);
       ExpressionFactory expressionFactory = facesContext.getApplication().getExpressionFactory();
-      return expressionFactory.createValueExpression(facesContext.getELContext(), expression, Object.class);
+      return expressionFactory.createValueExpression(facesContext.getELContext(), el, Object.class);
    }
 
    /**
@@ -132,5 +134,16 @@ public class FacesExpressionLanguageProvider implements ExpressionLanguageProvid
                            + "You should use PhaseAction and PhaseBinding to perform an deferred operation instead.");
       }
       return facesContext;
+   }
+
+   /**
+    * Adds #{..} to the expression if required
+    */
+   private String toELExpression(String s)
+   {
+      if (s != null && !s.startsWith("#{")) {
+         return "#{" + s + "}";
+      }
+      return s;
    }
 }

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverTest.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/resolver/FacesBeanNameResolverTest.java
@@ -49,7 +49,7 @@ public class FacesBeanNameResolverTest extends RewriteTest
    }
 
    @Test
-   public void testSpringFeatures()
+   public void testFacesBeanNameResolverFeatures()
    {
       HttpAction<HttpGet> action = get("/name/christian");
       Assert.assertEquals(200, action.getResponse().getStatusLine().getStatusCode());


### PR DESCRIPTION
Hey Lincoln,

the first version of `TypeBasedExpression` created expressions like `#{bean.property}`. Following the spirit of how Rewrite handles such expressions it now creates expressions without curly brackets like `bean.property`.

Christian
