### PR TITLE
Fixes Issue #109 - Context root is appended twice when using Navigate.to() class

### DIFF
--- a/config-prettyfaces-tests/src/test/java/org/ocpsoft/rewrite/prettyfaces/interaction/FacesNavigateInteractionBean.java
+++ b/config-prettyfaces-tests/src/test/java/org/ocpsoft/rewrite/prettyfaces/interaction/FacesNavigateInteractionBean.java
@@ -1,0 +1,17 @@
+package org.ocpsoft.rewrite.prettyfaces.interaction;
+
+import org.ocpsoft.rewrite.faces.navigate.Navigate;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named("facesInteraction")
+@RequestScoped
+public class FacesNavigateInteractionBean
+{
+
+   public Navigate navigate()
+   {
+      return Navigate.to("/page.jsf");
+   }
+}

--- a/config-prettyfaces-tests/src/test/java/org/ocpsoft/rewrite/prettyfaces/interaction/FacesNavigateInteractionTest.java
+++ b/config-prettyfaces-tests/src/test/java/org/ocpsoft/rewrite/prettyfaces/interaction/FacesNavigateInteractionTest.java
@@ -1,0 +1,33 @@
+package org.ocpsoft.rewrite.prettyfaces.interaction;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.prettyfaces.PrettyFacesTestBase;
+import org.ocpsoft.rewrite.test.RewriteTestBase;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+public class FacesNavigateInteractionTest extends RewriteTestBase
+{
+   @Deployment(testable = false)
+   public static WebArchive createDeployment()
+   {
+      return PrettyFacesTestBase.getDeployment()
+               .addClass(FacesNavigateInteractionBean.class)
+               .addAsWebResource("interaction/faces-navigate-page.xhtml", "page.xhtml")
+               .addAsWebInfResource("interaction/faces-navigate-pretty-config.xml", "pretty-config.xml");
+   }
+
+   @Test
+   public void testNavigate() throws Exception
+   {
+      HtmlPage firstPage = getWebClient("/page").getPage();
+      HtmlPage secondPage = firstPage.getElementById("navigate").click();
+      assertEquals(secondPage.getUrl().getPath(), getContextPath() + "/page");
+   }
+}

--- a/config-prettyfaces-tests/src/test/resources/interaction/faces-navigate-page.xhtml
+++ b/config-prettyfaces-tests/src/test/resources/interaction/faces-navigate-page.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+  xmlns:f="http://java.sun.com/jsf/core"
+  xmlns:h="http://java.sun.com/jsf/html"
+  xmlns:pretty="http://ocpsoft.com/prettyfaces"
+  xmlns:ui="http://java.sun.com/jsf/facelets">
+
+<head>
+  <title>Navigate Test</title>
+</head>
+
+<body>
+
+  <h1>Navigate Test</h1>
+
+  <h:form prependId="false">
+    <h:commandLink id="navigate" action="#{facesInteraction.navigate}" value="navigate" />
+  </h:form>
+
+</body>
+</html>
+

--- a/config-prettyfaces-tests/src/test/resources/interaction/faces-navigate-pretty-config.xml
+++ b/config-prettyfaces-tests/src/test/resources/interaction/faces-navigate-pretty-config.xml
@@ -1,0 +1,10 @@
+<pretty-config xmlns="http://ocpsoft.com/prettyfaces/3.3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://ocpsoft.com/prettyfaces/3.3.2 http://ocpsoft.com/xml/ns/prettyfaces/ocpsoft-pretty-faces-3.3.2.xsd">
+
+  <!-- Simple URL mapping -->
+  <url-mapping>
+    <pattern value="/page"></pattern>
+    <view-id>/page.jsf</view-id>
+  </url-mapping>
+
+</pretty-config>

--- a/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/RewriteNavigationHandler.java
+++ b/integration-faces/src/main/java/org/ocpsoft/rewrite/faces/RewriteNavigationHandler.java
@@ -155,7 +155,7 @@ public class RewriteNavigationHandler extends ConfigurableNavigationHandler
    private String prependContextPath(ExternalContext externalContext, String url)
    {
       String contextPath = externalContext.getRequestContextPath();
-      if ("/".equals(contextPath)) {
+      if ("/".equals(contextPath) || (url.startsWith(contextPath))) {
          return url;
       }
       return contextPath + url;


### PR DESCRIPTION
This is more like some observations I had regarding the problem and I don't think it's good as fix. I saw that when using `Navigate.to("some-view-mappable-to-pattern.jsf")` to workflow is something like:

```
 RewriteNavigationHandler.redirect()
  --> ExternalContext.encodeUrl()
    --> UrlMappingRuleAdaptor.perform()
      --> UrlMappingRuleAdaptor.rewritePrettyMappings() //here contextPath is prepended
```

So, contextPath might not be appended in different situations (where there's no mapping matched, or pretty-config used at all). I think the check in `RewriteNavigationHandler.prependContextPath()` actually comes with a problem, specifically when we have cases like _contextPath="/app"_ and _outbound="/applications.jsf"_. Also, doesn't seem right having contextPath managed in different or unrelated places.

What are your thoughts?
