### PR TITLE
Extended AddressBuilder in order to support "Scheme Sepcific Parts".

### DIFF
--- a/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/Address.java
+++ b/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/Address.java
@@ -79,6 +79,16 @@ public interface Address
    boolean isSchemeSet();
 
    /**
+    * Get the scheme section of this {@link Address}, or null if no scheme specific part is set.
+    */
+   String getSchemeSpecificPart();
+
+   /**
+    * Return <code>true</code> if this {@link Address} has a scheme specific part section, otherwise return <code>false</code>.
+    */
+   boolean isSchemeSpecificPartSet();
+
+   /**
     * Get the query section of this {@link Address}, or <code>null</code> if no query is set.
     */
    String getQuery();

--- a/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilder.java
+++ b/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilder.java
@@ -35,6 +35,7 @@ public class AddressBuilder
 {
    private volatile Address address;
    protected volatile CharSequence scheme;
+   protected volatile CharSequence schemeSpecificPart;
    protected volatile CharSequence domain;
    protected volatile Integer port;
    protected volatile CharSequence path;
@@ -69,14 +70,20 @@ public class AddressBuilder
     * Create a new {@link Address} from the given fully encoded URL. Improperly formatted or encoded URLs are not
     * parse-able and will result in an exception.
     * 
+    * @see http://en.wikipedia.org/wiki/URI_scheme
     * @throws IllegalArgumentException when the input URL or URL fragment is not valid.
     */
    public static Address create(String url) throws IllegalArgumentException
    {
       try {
          URI u = new URI(url);
-         return AddressBuilder.begin().scheme(u.getScheme()).domain(u.getHost()).port(u.getPort())
-                  .pathEncoded(u.getRawPath()).queryLiteral(u.getRawQuery()).anchor(u.getRawFragment()).build();
+         String scheme = u.getScheme();
+         String host = u.getHost();
+         if(scheme != null && host == null)
+            return AddressBuilder.begin().scheme(u.getScheme()).schemeSpecificPart(u.getRawSchemeSpecificPart()).build();
+         else
+           return AddressBuilder.begin().scheme(scheme).domain(host).port(u.getPort())
+             .pathEncoded(u.getRawPath()).queryLiteral(u.getRawQuery()).anchor(u.getRawFragment()).build();
       }
       catch (URISyntaxException e) {
          throw new IllegalArgumentException(
@@ -92,6 +99,15 @@ public class AddressBuilder
    {
       this.scheme = scheme;
       return new AddressBuilderScheme(this);
+   }
+
+   /**
+    * Set the scheme section of this {@link Address}.
+    */
+   AddressBuilderSchemeSpecificPart schemeSpecificPart(CharSequence schemeSpecificPart)
+   {
+      this.schemeSpecificPart = schemeSpecificPart;
+      return new AddressBuilderSchemeSpecificPart(this);
    }
 
    /**

--- a/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilderScheme.java
+++ b/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilderScheme.java
@@ -46,6 +46,14 @@ public class AddressBuilderScheme
    }
 
    /**
+    * Set the scheme specific part section of this {@link Address}.
+    */
+   public AddressBuilderSchemeSpecificPart schemeSpecificPart(CharSequence schemeSpecificPart)
+   {
+      return parent.schemeSpecificPart(schemeSpecificPart);
+   }
+   
+   /**
     * Set the port section of this {@link Address}.
     */
    public AddressBuilderPort port(int port)

--- a/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilderSchemeSpecificPart.java
+++ b/addressbuilder/src/main/java/org/ocpsoft/urlbuilder/AddressBuilderSchemeSpecificPart.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 <a href="mailto:fabmars@gmail.com">Fabien Marsaudz</a>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ocpsoft.urlbuilder;
+
+/**
+ * An {@link Address} with a scheme specific part section.
+ * 
+ * @author <a href="mailto:fabmars@gmail.com">Fabien Marsaud</a>
+ */
+public class AddressBuilderSchemeSpecificPart
+{
+   private AddressBuilder parent;
+
+   AddressBuilderSchemeSpecificPart(AddressBuilder parent)
+   {
+      this.parent = parent;
+   }
+
+   /**
+    * Generate an {@link Address} representing the current state of this {@link AddressBuilder}.
+    */
+   public Address build()
+   {
+      return parent.build();
+   }
+
+   @Override
+   public String toString()
+   {
+      return parent.toString();
+   }
+
+}

--- a/addressbuilder/src/test/java/org/ocpsoft/urlbuilder/AddressBuilderTest.java
+++ b/addressbuilder/src/test/java/org/ocpsoft/urlbuilder/AddressBuilderTest.java
@@ -251,4 +251,24 @@ public class AddressBuilderTest
 
    }
 
+   @Test
+   public void testBuildSchemeSpecificPart()
+   {
+      Assert.assertEquals("mailto:contact@ocpsoft.org?subject=Howdy Lincoln!",
+               AddressBuilder.begin()
+                         .scheme("mailto")
+                        .schemeSpecificPart("contact@ocpsoft.org?subject=Howdy Lincoln!")
+                        .toString());
+   }
+
+   @Test
+   public void testBuildSchemeSpecificPartResult()
+   {
+      Assert.assertEquals("mailto:contact@ocpsoft.org?subject=Howdy Lincoln!",
+               AddressBuilder.begin()
+               .scheme("mailto")
+               .schemeSpecificPart("contact@ocpsoft.org?subject=Howdy Lincoln!")
+               .build().toString());
+   }
+
 }


### PR DESCRIPTION
Thus, for example, "mailto:" or "tel:"-based URL's are now supported.
See http://en.wikipedia.org/wiki/URI_scheme for a list of possible SSPs.
Added 2 tests for AddressBuilding and result generation.
