### PR TITLE
Use wildcard type arguments when locating cdi beans

### DIFF
--- a/integration-cdi/src/main/java/org/ocpsoft/rewrite/cdi/util/WildcardTypeImpl.java
+++ b/integration-cdi/src/main/java/org/ocpsoft/rewrite/cdi/util/WildcardTypeImpl.java
@@ -1,0 +1,30 @@
+package org.ocpsoft.rewrite.cdi.util;
+
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+
+/**
+ * Implementation of WildcardType
+ *
+ * @author Bryn Cooke
+ */
+public class WildcardTypeImpl implements WildcardType {
+    private final Type[] upperBounds;
+    private final Type[] lowerBounds;
+
+    public WildcardTypeImpl(Type[] upperBounds, Type[] lowerBounds) {
+
+        this.upperBounds = upperBounds;
+        this.lowerBounds = lowerBounds;
+    }
+
+    @Override
+    public Type[] getUpperBounds() {
+        return upperBounds;
+    }
+
+    @Override
+    public Type[] getLowerBounds() {
+        return lowerBounds;
+    }
+}


### PR DESCRIPTION
By using a wildcard instead of Object for type parameters the correct beans are found.
