### PR TITLE
Removed 3rd party repositories from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,15 @@
             <scope>import</scope>
          </dependency>
 
+         <!-- Enforce this version of Xalan, because jboss-javaee-6.0 depends
+              on a version which isn't available in central. As this dependency
+              is used only in 'provided' scope, this should be ok. -->
+         <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.1</version>
+         </dependency>
+
          <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_2.5_spec</artifactId>


### PR DESCRIPTION
Travis builds from a clean local repository. So let's check if this still works without the 3rd party repositories.
