### PR TITLE
Methods to easier customize link url

### DIFF
--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/component/renderer/LinkRenderer.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/component/renderer/LinkRenderer.java
@@ -36,7 +36,7 @@ import com.ocpsoft.pretty.faces.util.PrettyURLBuilder;
 public class LinkRenderer extends Renderer
 {
    public static final String RENDERER_TYPE = "javax.faces.Link";
-   private final PrettyURLBuilder urlBuilder = new PrettyURLBuilder();
+   protected final PrettyURLBuilder urlBuilder = new PrettyURLBuilder();
 
    @Override
    public void encodeBegin(final FacesContext context, final UIComponent component) throws IOException
@@ -73,8 +73,7 @@ public class LinkRenderer extends Renderer
          PrettyConfig prettyConfig = prettyContext.getConfig();
          UrlMapping urlMapping = prettyConfig.getMappingById(mappingId);
 
-         String href = context.getExternalContext().getRequestContextPath()
-               + urlBuilder.build(urlMapping, true, urlBuilder.extractParameters(component));
+         String href = buildUrl(context, component, urlMapping);
 
          if ((link.getAnchor() != null) && link.getAnchor().length() > 0)
          {
@@ -119,6 +118,11 @@ public class LinkRenderer extends Renderer
       writeAttr(writer, "title", link.getTitle());
       writeAttr(writer, "type", link.getType());
 
+   }
+
+   protected String buildUrl(FacesContext context, UIComponent component, UrlMapping urlMapping) {
+      return context.getExternalContext().getRequestContextPath()
+                 + urlBuilder.build(urlMapping, true, urlBuilder.extractParameters(component));
    }
 
    private void writeAttr(final ResponseWriter writer, final String name, final String value) throws IOException


### PR DESCRIPTION
Hi,

In some frameworks such as DeltaSpike(ViewAccessScoped http://deltaspike.apache.org/documentation/jsf.html#__viewaccessscoped). They need to customize the generated url. In DeltaSpike case to add some parameters.

To acquire this in the Rewrite(rewrite-config-prettyfaces) I have to extend LinkRenderer and copy the full encodeBegin method customizing urlBuilder.build

It would be great to have a protected method only of the point that generate the url to make easy extend and customize it. 

In the pull request I added a protected buildUrl and change urlBuilder to be protected. 
