### PR TITLE
Support conditional parameters (f:param)

### DIFF
--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/util/PrettyURLBuilder.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/util/PrettyURLBuilder.java
@@ -54,7 +54,11 @@ public class PrettyURLBuilder
       {
          if (child instanceof UIParameter)
          {
-            results.add((UIParameter) child);
+            final UIParameter param = (UIParameter) child;
+            if (!param.isDisable())
+            {
+               results.add(param);
+            }
          }
       }
       return results;


### PR DESCRIPTION
Sometimes it easier to build urls with conditional f:param
For example, usually I have some links with css styles and customization like:

&lt;pretty:link mappingId="page" &gt;
	&lt;i class="style"/&gt;
	&lt;f:param value="#{myparam}" disable="#{not myLinkRequireParam}"/&gt;
&lt;/pretty:link&gt;

But once 'disable' is not verified pretty:link will always add it and fail for mismatch parameters
Then I have to do something like: (and always remember to change all links when change one of them)

&lt;pretty:link mappingId="page" rendered="#{not myLinkRequireParam}"&gt;
	&lt;i class="style"/&gt;
&lt;/pretty:link&gt;
&lt;pretty:link mappingId="page" rendered="#{myLinkRequireParam}"&gt;
	&lt;i class="style"/&gt;
	&lt;f:param value="#{myparam}" /&gt;
&lt;/pretty:link&gt;