### PR TITLE
LocaleTranspositionTest for outbound rewriting.

### DIFF
--- a/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionConfigurationProvider.java
+++ b/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionConfigurationProvider.java
@@ -43,6 +43,9 @@ public class LocaleTranspositionConfigurationProvider extends HttpConfigurationP
    public Configuration getConfiguration(final ServletContext context)
    {
       Configuration config = ConfigurationBuilder.begin()
+               .addRule(Join.path("/{lang}/{path}.xhtml").to("/{path}.xhtml"))
+               .where("path").transposedBy(LocaleTransposition.bundle("bundle", "lang"))
+
                .addRule(Join.path("/{lang}/{path}").to("/{path}"))
                .where("path").configuredBy(LocaleTransposition.bundle("bundle", "lang"))
 

--- a/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionTest.java
+++ b/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionTest.java
@@ -46,9 +46,11 @@ public class LocaleTranspositionTest extends RewriteTest
       WebArchive deployment = RewriteTest
                .getDeployment()
                .addPackages(true, Root.class.getPackage())
+               .setWebXML(new File("src/test/webapp/WEB-INF/web.xml"))
                .addAsServiceProvider(ConfigurationProvider.class, LocaleTranspositionConfigurationProvider.class)
                .addAsWebResource(new StringAsset("search page"), "search")
                .addAsWebResource(new StringAsset("library page"), "library")
+               .addAsWebResource(new File("src/test/webapp/search.xhtml"))
                .addAsResource(new File("src/test/resources/bundle_fr.properties"))
                .addAsResource(new File("src/test/resources/bundle_en.properties"));
       return deployment;
@@ -75,6 +77,14 @@ public class LocaleTranspositionTest extends RewriteTest
       HttpAction<HttpGet> action = get("/fr/bibliothèque");
       Assert.assertEquals(200, action.getResponse().getStatusLine().getStatusCode());
       Assert.assertEquals("library page", action.getResponseContent());
+   }
+
+   @Test
+   public void testI18nSupportOutbound() throws Exception
+   {
+      HttpAction<HttpGet> action = get("/en/search.xhtml");
+      Assert.assertEquals(200, action.getResponse().getStatusLine().getStatusCode());
+      Assert.assertThat(action.getResponseContent(), org.junit.matchers.JUnitMatchers.containsString("/en/search"));
    }
 
    /**

--- a/api-tests/src/test/webapp/WEB-INF/web.xml
+++ b/api-tests/src/test/webapp/WEB-INF/web.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+		http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+	<context-param>
+		<param-name>javax.faces.PROJECT_STAGE</param-name>
+		<param-value>Development</param-value>
+	</context-param>
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>Faces Servlet</servlet-name>
+		<url-pattern>*.xhtml</url-pattern>
+	</servlet-mapping>
+</web-app>

--- a/api-tests/src/test/webapp/search.xhtml
+++ b/api-tests/src/test/webapp/search.xhtml
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:h="http://java.sun.com/jsf/html" xmlns:f="http://java.sun.com/jsf/core">
+	<h:head>
+		<meta charset="utf-8" />
+	</h:head>
+	<h:body>
+		<h:link outcome="/search.xhtml" value="Test"></h:link>
+	</h:body>
+</html>


### PR DESCRIPTION
As requested by Christian [here](http://www.ocpsoft.org/support/topic/outbound-rule-for-internationalize-your-urls-2/page/2/), an enhancement of LocaleTranspositionTest for outbound rewriting was created.