### PR TITLE
Wrap original exception to preserve complete stack trace

### DIFF
--- a/impl-servlet/src/main/java/org/ocpsoft/rewrite/servlet/impl/DefaultHttpRewriteProvider.java
+++ b/impl-servlet/src/main/java/org/ocpsoft/rewrite/servlet/impl/DefaultHttpRewriteProvider.java
@@ -181,7 +181,7 @@ public class DefaultHttpRewriteProvider extends HttpRewriteProvider implements N
                   }
                }
                catch (Exception e) {
-                  throw new RewriteException("Error during [" + event + "] while executing rule [" + rule + "]");
+                  throw new RewriteException("Error during [" + event + "] while executing rule [" + rule + "]", e);
                }
             }
          }
@@ -343,7 +343,7 @@ public class DefaultHttpRewriteProvider extends HttpRewriteProvider implements N
                   }
                }
                catch (Exception e) {
-                  throw new RewriteException("Error during [" + event + "] while executing rule [" + rule + "]");
+                  throw new RewriteException("Error during [" + event + "] while executing rule [" + rule + "]", e);
                }
             }
          }


### PR DESCRIPTION
Hi everybody

I ran into a problem with rewriting an url and could not analyze the original problem because this code throws away part of the stack trace. This commit should fix it.

Thank you for your work!
Roman