### PR TITLE
skip versioned classes in Java 9 Multi-release JAR files

### DIFF
--- a/annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/AbstractClassFinder.java
+++ b/annotations-impl/src/main/java/org/ocpsoft/rewrite/annotation/scan/AbstractClassFinder.java
@@ -123,6 +123,11 @@ public abstract class AbstractClassFinder implements ClassFinder
    protected boolean mustProcessClass(String className)
    {
 
+      // skip versioned classes in Java 9 Multi-release JAR files
+      if (className.startsWith("META-INF.versions")) {
+         return false;
+      }
+       
       // the default package
       String packageName = "";
 


### PR DESCRIPTION
If you use a jar file with files in the META-INF/versions directory on JRE 8, rewrite tries to load these classes in the WebLibFinder. This small fix avoids loading such classes at first fix to avoid Classloading-Exceptions. In a next step the decision should be based on the running JRE.