### PR TITLE
Mark TOMEE as an allowable failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
       jdk: oraclejdk8
     - env: CONTAINER=TOMEE_MANAGED_1.5
       jdk: openjdk7
+  allow_failures:
+    - env: CONTAINER=TOMEE_MANAGED_1.5
 notifications:
   email:
     - "ocpsoft-ci@googlegroups.com"


### PR DESCRIPTION
Currently, TOMEE_MANAGED_1.5 fails on every build, presumably due to configuration issues.  This change marks that as allowable, so if the other four builds succeed, it will show green rather than red as it does now.  The TOMEE build will still show red on the details screen, but the summary view on GitHub will show green.  

This way, if someone fixes TOMEE, it will be visible in Travis.  But this way, red means failed rather than "check if anything other than TOMEE failed."  A typical build with all successes except a TOMEE failure will show as green.  At least that's what https://docs.travis-ci.com/user/customizing-the-build#rows-that-are-allowed-to-fail says.  I can't test without committing and requesting a pull.