### PR TITLE
Jetty ref

### DIFF
--- a/test-harness/src/main/resources/jetty-env.xml
+++ b/test-harness/src/main/resources/jetty-env.xml
@@ -5,7 +5,7 @@
 
    <Set class="org.eclipse.jetty.util.resource.Resource" name="defaultUseCaches">false</Set>
    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
-      <Arg><Ref id="webAppCtx"/></Arg>
+      <Arg><Ref refid="webAppCtx"/></Arg>
       <Arg>type</Arg>
       <Arg type="java.lang.String">Embedded</Arg>
       <Arg type="boolean">true</Arg>
@@ -17,7 +17,7 @@
    </New>
    <!-- I can't figure out why org.eclipse.jetty.plus.jndi.Resource doesn't work here, but it doesn't -->
    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
-      <Arg><Ref id="webAppCtx"/></Arg>
+      <Arg><Ref refid="webAppCtx"/></Arg>
       <Arg>BeanManager</Arg>
       <Arg>
          <New class="javax.naming.Reference">


### PR DESCRIPTION
This XML file is invalid, as it has three elements with the same id attribute.  The correct attribute is refid, which indicates a reference to another element.  Use of id to mean refid is deprecated, as per http://www.eclipse.org/jetty/configure.dtd

This pull request is separate from the other active pull request.  It is only related in that both involve things that my IDE finds incorrect.  Neither should block or require the other.  