### PR TITLE
Remove collection casts

### DIFF
--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/PrettyConfigurator.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/PrettyConfigurator.java
@@ -57,10 +57,10 @@ public class PrettyConfigurator
       {
          final PrettyConfigBuilder builder = new PrettyConfigBuilder();
 
-         ServiceLoader<ConfigurationProvider> configLoader = ServiceLoader.load(ConfigurationProvider.class);
-         for (ConfigurationProvider p : configLoader)
+         ServiceLoader<?> configLoader = ServiceLoader.load(ConfigurationProvider.class);
+         for (Object p : configLoader)
          {
-            builder.addFromConfig(p.loadConfiguration(servletContext));
+            builder.addFromConfig(((ConfigurationProvider) p).loadConfiguration(servletContext));
          }
 
          config = builder.build();
@@ -73,10 +73,10 @@ public class PrettyConfigurator
 
          config = parenting.processConfiguration(servletContext, config);
 
-         ServiceLoader<ConfigurationPostProcessor> postProcessors = ServiceLoader.load(ConfigurationPostProcessor.class);
-         for (ConfigurationPostProcessor p : postProcessors)
+         ServiceLoader<?> postProcessors = ServiceLoader.load(ConfigurationPostProcessor.class);
+         for (Object p : postProcessors)
          {
-            config = p.processConfiguration(servletContext, config);
+            config = ((ConfigurationPostProcessor) p).processConfiguration(servletContext, config);
          }
 
          ConfigurationPostProcessor validating = new ValidatingPostProcessor();

--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/PrettyConfigurator.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/PrettyConfigurator.java
@@ -57,10 +57,10 @@ public class PrettyConfigurator
       {
          final PrettyConfigBuilder builder = new PrettyConfigBuilder();
 
-         ServiceLoader<?> configLoader = ServiceLoader.load(ConfigurationProvider.class);
-         for (Object p : configLoader)
+         ServiceLoader<ConfigurationProvider> configLoader = ServiceLoader.loadTypesafe(ConfigurationProvider.class);
+         for (ConfigurationProvider p : configLoader)
          {
-            builder.addFromConfig(((ConfigurationProvider) p).loadConfiguration(servletContext));
+            builder.addFromConfig(p.loadConfiguration(servletContext));
          }
 
          config = builder.build();
@@ -73,10 +73,10 @@ public class PrettyConfigurator
 
          config = parenting.processConfiguration(servletContext, config);
 
-         ServiceLoader<?> postProcessors = ServiceLoader.load(ConfigurationPostProcessor.class);
-         for (Object p : postProcessors)
+         ServiceLoader<ConfigurationPostProcessor> postProcessors = ServiceLoader.loadTypesafe(ConfigurationPostProcessor.class);
+         for (ConfigurationPostProcessor p : postProcessors)
          {
-            config = ((ConfigurationPostProcessor) p).processConfiguration(servletContext, config);
+            config = p.processConfiguration(servletContext, config);
          }
 
          ConfigurationPostProcessor validating = new ValidatingPostProcessor();

--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/reload/PrettyConfigReloader.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/reload/PrettyConfigReloader.java
@@ -107,12 +107,12 @@ public class PrettyConfigReloader
    {
 
       // create the ServiceLoader for the SPI
-      ServiceLoader<?> serviceLoader = ServiceLoader.load(DevelopmentModeDetector.class);
+      ServiceLoader<DevelopmentModeDetector> serviceLoader = ServiceLoader.loadTypesafe(DevelopmentModeDetector.class);
 
       // we need a list to be able to sort it
       List<DevelopmentModeDetector> detectors = new ArrayList<DevelopmentModeDetector>();
-      for (Object detector : serviceLoader) {
-         detectors.add((DevelopmentModeDetector) detector);
+      for (DevelopmentModeDetector detector : serviceLoader) {
+         detectors.add(detector);
       }
 
       // sort them by priority

--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/reload/PrettyConfigReloader.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/reload/PrettyConfigReloader.java
@@ -107,12 +107,12 @@ public class PrettyConfigReloader
    {
 
       // create the ServiceLoader for the SPI
-      ServiceLoader<DevelopmentModeDetector> serviceLoader = ServiceLoader.load(DevelopmentModeDetector.class);
+      ServiceLoader<?> serviceLoader = ServiceLoader.load(DevelopmentModeDetector.class);
 
       // we need a list to be able to sort it
       List<DevelopmentModeDetector> detectors = new ArrayList<DevelopmentModeDetector>();
-      for (DevelopmentModeDetector detector : serviceLoader) {
-         detectors.add(detector);
+      for (Object detector : serviceLoader) {
+         detectors.add((DevelopmentModeDetector) detector);
       }
 
       // sort them by priority

--- a/test-harness/src/main/resources/jetty-env.xml
+++ b/test-harness/src/main/resources/jetty-env.xml
@@ -5,7 +5,7 @@
 
    <Set class="org.eclipse.jetty.util.resource.Resource" name="defaultUseCaches">false</Set>
    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
-      <Arg><Ref id="webAppCtx"/></Arg>
+      <Arg><Ref refid="webAppCtx"/></Arg>
       <Arg>type</Arg>
       <Arg type="java.lang.String">Embedded</Arg>
       <Arg type="boolean">true</Arg>
@@ -17,7 +17,7 @@
    </New>
    <!-- I can't figure out why org.eclipse.jetty.plus.jndi.Resource doesn't work here, but it doesn't -->
    <New class="org.eclipse.jetty.plus.jndi.EnvEntry">
-      <Arg><Ref id="webAppCtx"/></Arg>
+      <Arg><Ref refid="webAppCtx"/></Arg>
       <Arg>BeanManager</Arg>
       <Arg>
          <New class="javax.naming.Reference">


### PR DESCRIPTION
Since Java doesn't like casting Collection to Collection<Type>, move the casts to the individual objects.  This simply reduces compiler noise.  I.e. my IDE was producing warnings but stopped after this change.  

Includes merge/rebase commits that could be squashed.  Only the final commit matters.  