### PR TITLE
Add entry for tests failing

### DIFF
--- a/documentation/src/main/asciidoc/faq.asciidoc
+++ b/documentation/src/main/asciidoc/faq.asciidoc
@@ -55,3 +55,23 @@ For more details about this issue, have a look at this great
 link:http://stackoverflow.com/a/8050589/395181[stackoverflow answer]
 by link:http://stackoverflow.com/users/157882/balusc[BalusC].
 
+=== Why am I getting errors when I run tests?  
+
+If you are getting errors about not being able to find a class that is 
+in a package not included by the current module under test or if you 
+are receiving the following error:  
+
+____
+org.jboss.arquillian.container.test.impl.client.deployment.ValidationException: +
+DeploymentScenario contains a target (_DEFAULT_) not matching 
+any defined Container in the registry. +
+Please include at least 1 Deployable Container on your Classpath.
+____
+
+This may mean that you do not have a Maven profile defined for that 
+project.  Without the Maven profile, Arquillian does not know where 
+to deploy the code for testing.  You can find the different profiles 
+defined in the Rewrite parent pom.xml file.  The GLASSFISH_MANAGED_3.1 
+and GLASSFISH_MANAGED_4.0 profiles will download the container server 
+for you.  
+


### PR DESCRIPTION
I actually spent some time figuring out how this worked, as the error that I received originally implied that there was a dependency missing.  The actual problem is that the tests deploy the entire application rather than just that Maven module.  Since this is basically the first thing that someone has to do to build the project, it may be worth adding this information to the FAQ.  