### PR TITLE
use openjdk8 with travis. oracle is gone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,10 @@ after_success:
   - "bash ./.travis-deploy.sh"
 matrix:
   include:
-    - env: CONTAINER=JBOSS_AS_MANAGED_7.X
-      jdk: openjdk7
     - env: CONTAINER=WILDFLY_MANAGED_8
-      jdk: oraclejdk8
-    - env: CONTAINER=GLASSFISH_MANAGED_3.1
-      jdk: openjdk7
+      jdk: openjdk8
     - env: CONTAINER=GLASSFISH_MANAGED_4.0
-      jdk: oraclejdk8
-    - env: CONTAINER=TOMEE_MANAGED_1.5
-      jdk: openjdk7
-  allow_failures:
-    - env: CONTAINER=TOMEE_MANAGED_1.5
+      jdk: openjdk8
 notifications:
   email:
     - "ocpsoft-ci@googlegroups.com"


### PR DESCRIPTION
Travis has removed support or OracleJDK so updating the travis test config to use openjdk8