### PR TITLE
Added repository definition in example pom config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Get Started
            <artifactId>rewrite-servlet</artifactId>
            <version>${rewrite.version}</version>
         </dependency>
+	
+	...
+	
+	<repository>
+	  <id>sonatype-snapshots</id>
+	  <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+	</repository>
 
 3. Add a configuration provider implementing the 'org.ocpsoft.rewrite.config.ConfigurationProvider' interface, or extending from the abstract HttpConfigurationProvider class for convenience:
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Get Started
            <version>${rewrite.version}</version>
         </dependency>
 	
-	...
+You may wish to also add the sonatype-snapshots repo definition in your pom.xml:
 	
-	<repository>
-	  <id>sonatype-snapshots</id>
-	  <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-	</repository>
+        <repository>
+          <id>sonatype-snapshots</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
 
 3. Add a configuration provider implementing the 'org.ocpsoft.rewrite.config.ConfigurationProvider' interface, or extending from the abstract HttpConfigurationProvider class for convenience:
 


### PR DESCRIPTION
Adding just the dependency resulted in various maven errors, indicating the dependency could not be found.

It only worked after the sonatype-snapshots repo was explicitly mentioned as in the snippet, even though ${rewrite.version} was 3.4.4.Final (i.e. not a snapshot).