### PR TITLE
Update commons-beanutils version in config-prettyfaces

### DIFF
--- a/config-prettyfaces/pom.xml
+++ b/config-prettyfaces/pom.xml
@@ -12,6 +12,7 @@
 
    <properties>
       <version.digester>2.0</version.digester>
+      <version.beanutils>1.9.4</version.beanutils>
    </properties>
 
    <dependencies>
@@ -43,6 +44,11 @@
          <groupId>commons-digester</groupId>
          <artifactId>commons-digester</artifactId>
          <version>${version.digester}</version>
+      </dependency>
+      <dependency>
+         <groupId>commons-beanutils</groupId>
+         <artifactId>commons-beanutils</artifactId>
+         <version>${version.beanutils}</version>
       </dependency>
       <dependency>
          <groupId>org.jboss.spec.javax.servlet</groupId>


### PR DESCRIPTION
The update of the commons-beanutils library in the config-prettyfaces closes the following secutiry issues: CVE-2014-0114, CVE-2019-10086