### PR TITLE
Improve EE10 compatibility

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 19 ]
+        java: [ 17 ]
         container: [ 'WILDFLY_MANAGED', 'WILDFLY_REMOTE', 'PAYARA_MANAGED' ]
         jakarta: [ 9, 10 ]
     name: Integration tests (Java ${{ matrix.java }}, Jakarta EE ${{ matrix.jakarta }}, Container ${{ matrix.container }})

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: Maven
 
 on:
   - push
@@ -12,6 +12,7 @@ jobs:
       matrix:
         java: [ 17, 19 ]
         jakarta: [ 9, 10 ]
+    name: Build w/o tests (Java ${{ matrix.java }}, Jakarta EE ${{ matrix.jakarta }})
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -30,6 +31,7 @@ jobs:
       matrix:
         java: [ 17, 19 ]
         jakarta: [ 9, 10 ]
+    name: Unit tests (Java ${{ matrix.java }}, Jakarta EE ${{ matrix.jakarta }})
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -50,6 +52,7 @@ jobs:
         java: [ 17, 19 ]
         container: [ 'WILDFLY_MANAGED', 'WILDFLY_REMOTE', 'PAYARA_MANAGED' ]
         jakarta: [ 9, 10 ]
+    name: Integration tests (Java ${{ matrix.java }}, Jakarta EE ${{ matrix.jakarta }}, Container ${{ matrix.container }})
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 18 ]
+        jakarta: [ 9, 10 ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -19,7 +20,7 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - run: ./mvnw --batch-mode --update-snapshots install -DskipTests
+      - run: ./mvnw --batch-mode --update-snapshots install -DskipTests -P EE${{ matrix.jakarta }}
 
   unit-test:
     runs-on: ubuntu-latest
@@ -28,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 18 ]
+        jakarta: [ 9, 10 ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -36,8 +38,8 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - run: ./mvnw --batch-mode --update-snapshots install -DskipTests
-      - run: ./mvnw --batch-mode test
+      - run: ./mvnw --batch-mode --update-snapshots install -DskipTests -P EE${{ matrix.jakarta }}
+      - run: ./mvnw --batch-mode test -P EE${{ matrix.jakarta }}
 
   integration-test:
     runs-on: ubuntu-latest
@@ -46,7 +48,8 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 17, 18 ]
-        container: [ 'WILDFLY_MANAGED', 'WILDFLY_REMOTE' ]
+        container: [ 'WILDFLY_MANAGED', 'WILDFLY_REMOTE', 'PAYARA_MANAGED' ]
+        jakarta: [ 9, 10 ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -55,5 +58,5 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - run: ./mvnw -V --batch-mode --update-snapshots install -DskipTests
-      - run: ./mvnw -V --batch-mode -P ${{ matrix.container }} verify
+      - run: ./mvnw -V --batch-mode --update-snapshots install -DskipTests -P EE${{ matrix.jakarta }}
+      - run: ./mvnw -V --batch-mode -P ${{ matrix.container }},EE${{ matrix.jakarta }} verify

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 18 ]
+        java: [ 17, 19 ]
         jakarta: [ 9, 10 ]
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 18 ]
+        java: [ 17, 19 ]
         jakarta: [ 9, 10 ]
     steps:
       - uses: actions/checkout@v3
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 17, 18 ]
+        java: [ 17, 19 ]
         container: [ 'WILDFLY_MANAGED', 'WILDFLY_REMOTE', 'PAYARA_MANAGED' ]
         jakarta: [ 9, 10 ]
     steps:

--- a/addressbuilder/pom.xml
+++ b/addressbuilder/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/annotations-api/pom.xml
+++ b/annotations-api/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
    

--- a/annotations-impl/pom.xml
+++ b/annotations-impl/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/api-el/pom.xml
+++ b/api-el/pom.xml
@@ -13,7 +13,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/api-servlet/pom.xml
+++ b/api-servlet/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/api-tests/pom.xml
+++ b/api-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
    

--- a/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionIT.java
+++ b/api-tests/src/test/java/org/ocpsoft/rewrite/transposition/LocaleTranspositionIT.java
@@ -48,6 +48,9 @@ public class LocaleTranspositionIT extends RewriteIT
                .getDeployment()
                .addPackages(true, Root.class.getPackage())
                .setWebXML(new File("src/test/webapp/WEB-INF/web.xml"))
+               // This is necessary as of Faces 4.0 - CDI needs to be enabled explicitly!
+               // See also https://github.com/eclipse-ee4j/glassfish/issues/23917
+               .addAsWebInfResource(new File("src/test/webapp/WEB-INF/beans.xml"))
                .addAsServiceProvider(ConfigurationProvider.class, LocaleTranspositionConfigurationProvider.class)
                .addAsWebResource(new StringAsset("search page"), "search")
                .addAsWebResource(new StringAsset("library page"), "library")

--- a/api-tests/src/test/webapp/WEB-INF/beans.xml
+++ b/api-tests/src/test/webapp/WEB-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+    xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd">
+    <!-- CDI configuration here. -->
+</beans>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,7 +14,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
    

--- a/config-annotations/pom.xml
+++ b/config-annotations/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-prettyfaces-tests/pom.xml
+++ b/config-prettyfaces-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-prettyfaces-tests/pom.xml
+++ b/config-prettyfaces-tests/pom.xml
@@ -66,7 +66,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
+               <testFailureIgnore>${it.ignore.selectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/config-prettyfaces-tests/pom.xml
+++ b/config-prettyfaces-tests/pom.xml
@@ -66,7 +66,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>true</testFailureIgnore>
+               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/config-prettyfaces/pom.xml
+++ b/config-prettyfaces/pom.xml
@@ -90,7 +90,6 @@
       <dependency>
          <groupId>org.glassfish</groupId>
          <artifactId>jakarta.faces</artifactId>
-         <version>3.0.0</version>
          <scope>test</scope>
       </dependency>
       <dependency>

--- a/config-prettyfaces/pom.xml
+++ b/config-prettyfaces/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-servlet-tests/pom.xml
+++ b/config-servlet-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-servlet/pom.xml
+++ b/config-servlet/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/config-servlet/src/test/java/org/ocpsoft/rewrite/servlet/config/ParameterWildcardConfigurationIT.java
+++ b/config-servlet/src/test/java/org/ocpsoft/rewrite/servlet/config/ParameterWildcardConfigurationIT.java
@@ -24,6 +24,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.ocpsoft.rewrite.category.IgnoreForGlassfish3;
 import org.ocpsoft.rewrite.category.IgnoreForGlassfish4;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.category.IgnoreForWildfly;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.test.RewriteIT;
@@ -35,7 +36,7 @@ import org.ocpsoft.rewrite.test.RewriteIT;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @RunWith(Arquillian.class)
-@Category({ IgnoreForWildfly.class, IgnoreForGlassfish3.class, IgnoreForGlassfish4.class })
+@Category({ IgnoreForWildfly.class, IgnoreForGlassfish3.class, IgnoreForGlassfish4.class, IgnoreForPayara.class })
 public class ParameterWildcardConfigurationIT
 {
    @Deployment(testable = false)

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/impl-servlet-tests/pom.xml
+++ b/impl-servlet-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/config/ConfigurationDeploymentIT.java
+++ b/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/config/ConfigurationDeploymentIT.java
@@ -25,6 +25,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.ocpsoft.rewrite.category.IgnoreForGlassfish3;
 import org.ocpsoft.rewrite.category.IgnoreForGlassfish4;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.category.IgnoreForWildfly;
 import org.ocpsoft.rewrite.servlet.ServletRoot;
 import org.ocpsoft.rewrite.test.RewriteIT;
@@ -36,7 +37,7 @@ import org.ocpsoft.rewrite.test.RewriteIT;
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  */
 @RunWith(Arquillian.class)
-@Category({ IgnoreForWildfly.class, IgnoreForGlassfish3.class, IgnoreForGlassfish4.class })
+@Category({ IgnoreForWildfly.class, IgnoreForGlassfish3.class, IgnoreForGlassfish4.class, IgnoreForPayara.class })
 public class ConfigurationDeploymentIT
 {
    @Deployment(testable = false)

--- a/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/validate/BindingValidationIT.java
+++ b/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/validate/BindingValidationIT.java
@@ -20,7 +20,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.servlet.ServletRoot;
 import org.ocpsoft.rewrite.test.HttpAction;
@@ -44,6 +46,9 @@ public class BindingValidationIT extends RewriteIT
    }
 
    @Test
+   // TODO: This test triggers a socket timeout for unknown reasons on Payara 5 and 6, as the connection is not
+   //       getting closed with an empty body. Status code & headers are sent correctly. Needs to be examined further.
+   @Category(IgnoreForPayara.class)
    public void testConfigurationProviderForward() throws Exception
    {
       HttpAction action = get("/v/valid");

--- a/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/wrapper/WrappedResponseStreamIT.java
+++ b/impl-servlet-tests/src/test/java/org/ocpsoft/rewrite/servlet/wrapper/WrappedResponseStreamIT.java
@@ -23,6 +23,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.category.IgnoreForWildfly;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.servlet.ServletRoot;
@@ -59,11 +60,14 @@ public class WrappedResponseStreamIT extends RewriteIT
 
    /**
     * Ignored on Wildlfy because there seems to be some issue with the content length.
-    * 
-    * @see https://github.com/ocpsoft/rewrite/issues/145
+    *
+    * 2022-10-25: Retested with Wildfly 27 and Payara 6: the "Content-Encoding" array is (still) empty,
+    *             same error for both. Now ignoring for Payara, too.
+    *
+    * @see <a href="https://github.com/ocpsoft/rewrite/issues/145">GitHub Issue 145</a>
     */
    @Test
-   @Category(IgnoreForWildfly.class)
+   @Category({IgnoreForWildfly.class, IgnoreForPayara.class})
    public void testWrappedResponseStreamToGZip() throws Exception
    {
 

--- a/impl-servlet/pom.xml
+++ b/impl-servlet/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/impl-tests/pom.xml
+++ b/impl-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-cdi-tests/pom.xml
+++ b/integration-cdi-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-cdi/pom.xml
+++ b/integration-cdi/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-cdi/src/main/resources/META-INF/beans.xml
+++ b/integration-cdi/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,7 @@
-<beans xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
-	
+<?xml version="1.0" encoding="UTF-8"?>
+<beans
+	xmlns="https://jakarta.ee/xml/ns/jakartaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+	version="4.0" bean-discovery-mode="all">
 </beans>

--- a/integration-cdi/src/test/java/org/ocpsoft/rewrite/cdi/bridge/CdiMultipleFeaturesIT.java
+++ b/integration-cdi/src/test/java/org/ocpsoft/rewrite/cdi/bridge/CdiMultipleFeaturesIT.java
@@ -17,7 +17,6 @@ package org.ocpsoft.rewrite.cdi.bridge;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +24,8 @@ import org.ocpsoft.rewrite.cdi.bind.BindingBean;
 import org.ocpsoft.rewrite.cdi.bind.ExpressionLanguageTestConfigurationProvider;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteIT;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,7 +44,8 @@ public class CdiMultipleFeaturesIT extends RewriteIT
    {
       return RewriteIT
                .getDeployment()
-               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml")
+               // Necessary as of CDI 4.0 because we need bean-discovery-mode="all"
+               .addAsWebInfResource(new File("src/main/resources/META-INF/beans.xml"))
                .addClasses(BindingBean.class, ExpressionLanguageTestConfigurationProvider.class, MockBean.class,
                         RewriteLifecycleEventObserver.class, ServiceEnricherTestConfigProvider.class);
    }

--- a/integration-cdi/src/test/java/org/ocpsoft/rewrite/cdi/resolver/CdiBeanNameResolverIT.java
+++ b/integration-cdi/src/test/java/org/ocpsoft/rewrite/cdi/resolver/CdiBeanNameResolverIT.java
@@ -17,12 +17,13 @@ package org.ocpsoft.rewrite.cdi.resolver;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteIT;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,8 +38,9 @@ public class CdiBeanNameResolverIT extends RewriteIT
    public static WebArchive getDeployment()
    {
       return RewriteIT.getDeployment()
-               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml")
-               .addClasses(CdiBeanNameResolverBean.class, CdiBeanNameResolverConfigProvider.class);
+          // Necessary as of CDI 4.0 because we need bean-discovery-mode="all"
+          .addAsWebInfResource(new File("src/main/resources/META-INF/beans.xml"))
+          .addClasses(CdiBeanNameResolverBean.class, CdiBeanNameResolverConfigProvider.class);
    }
 
    @Test

--- a/integration-faces-tests/pom.xml
+++ b/integration-faces-tests/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-faces-tests/pom.xml
+++ b/integration-faces-tests/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
+               <testFailureIgnore>${it.ignore.selectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/integration-faces-tests/pom.xml
+++ b/integration-faces-tests/pom.xml
@@ -75,7 +75,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>true</testFailureIgnore>
+               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/integration-faces/pom.xml
+++ b/integration-faces/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/PhaseOperationIT.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/PhaseOperationIT.java
@@ -20,7 +20,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.faces.test.FacesBase;
 import org.ocpsoft.rewrite.test.HttpAction;
@@ -65,6 +67,9 @@ public class PhaseOperationIT extends RewriteIT
    }
 
    @Test
+   // TODO: This test triggers a socket timeout for unknown reasons on Payara 5 and 6, as the connection is not
+   //       getting closed with an empty body. Status code & headers are sent correctly. Needs to be examined further.
+   @Category(IgnoreForPayara.class)
    public void testPhaseBindingDefersValue() throws Exception
    {
       HttpAction action = get("/binding/lincoln");

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/cdn/SchemalessCDNRuleIT.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/cdn/SchemalessCDNRuleIT.java
@@ -22,7 +22,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.ocpsoft.rewrite.category.IgnoreForPayara;
+import org.ocpsoft.rewrite.category.IgnoreForPayara5;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.faces.test.FacesBase;
 import org.ocpsoft.rewrite.test.HttpAction;
@@ -46,7 +46,7 @@ public class SchemalessCDNRuleIT extends RewriteITBase
 
    @Test
    // TODO: Remove this ignore & try again when https://github.com/payara/Payara/issues/5842 is resolved!
-   @Category(IgnoreForPayara.class)
+   @Category(IgnoreForPayara5.class)
    public void shouldRewriteToSchemalessURL() throws Exception
    {
 

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/cdn/SchemalessCDNRuleIT.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/cdn/SchemalessCDNRuleIT.java
@@ -20,7 +20,9 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.faces.test.FacesBase;
 import org.ocpsoft.rewrite.test.HttpAction;
@@ -43,6 +45,8 @@ public class SchemalessCDNRuleIT extends RewriteITBase
    }
 
    @Test
+   // TODO: Remove this ignore & try again when https://github.com/payara/Payara/issues/5842 is resolved!
+   @Category(IgnoreForPayara.class)
    public void shouldRewriteToSchemalessURL() throws Exception
    {
 

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/error/ErrorPageIT.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/error/ErrorPageIT.java
@@ -18,6 +18,7 @@ package org.ocpsoft.rewrite.faces.error;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +40,7 @@ public class ErrorPageIT extends RewriteITBase
       return RewriteIT.getDeploymentNoWebXml()
                .setWebXML("error-page-web.xml")
                .addAsWebInfResource("faces-config.xml", "faces-config.xml")
+               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml")
                .addClass(ErrorPageConfig.class)
                .addAsServiceProviderAndClasses(ConfigurationProvider.class, ErrorPageConfig.class)
                .addAsWebResource(EmptyAsset.INSTANCE, "some-page.xhtml")

--- a/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/test/FacesBase.java
+++ b/integration-faces/src/test/java/org/ocpsoft/rewrite/faces/test/FacesBase.java
@@ -1,5 +1,6 @@
 package org.ocpsoft.rewrite.faces.test;
 
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.ocpsoft.rewrite.test.RewriteIT;
 
@@ -10,7 +11,8 @@ public class FacesBase
       return RewriteIT
                .getDeploymentNoWebXml()
                .setWebXML("faces-web.xml")
-               .addAsWebInfResource("faces-config.xml", "faces-config.xml");
+               .addAsWebInfResource("faces-config.xml", "faces-config.xml")
+               // Necessary as of Faces 4.0 because CDI and Faces have been separated now.
+               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml");
    }
-
 }

--- a/integration-faces/src/test/resources/faces-config.xml
+++ b/integration-faces/src/test/resources/faces-config.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<faces-config xmlns="http://java.sun.com/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd"
-	version="2.0">
-
-	<name>rewrite_integration_faces_tests</name>
+<faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+			  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd"
+			  version="3.0">
+	
+<name>rewrite_integration_faces_tests</name>
 
 </faces-config>

--- a/integration-faces/src/test/resources/faces-web.xml
+++ b/integration-faces/src/test/resources/faces-web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	version="3.0"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+		 version="5.0">
 
     <servlet>
       <servlet-name>Faces Servlet</servlet-name>

--- a/integration-gwt/pom.xml
+++ b/integration-gwt/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/integration-spring/pom.xml
+++ b/integration-spring/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/integration-spring/src/test/java/org/ocpsoft/rewrite/spring/SpringFeaturesIT.java
+++ b/integration-spring/src/test/java/org/ocpsoft/rewrite/spring/SpringFeaturesIT.java
@@ -17,9 +17,12 @@ package org.ocpsoft.rewrite.spring;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara5;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteIT;
 import org.springframework.web.context.WebApplicationContext;
@@ -40,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Kaltepoth
  */
 @RunWith(Arquillian.class)
+@Category(IgnoreForPayara5.class)
 public class SpringFeaturesIT extends RewriteIT
 {
 
@@ -49,7 +53,9 @@ public class SpringFeaturesIT extends RewriteIT
       return RewriteIT.getDeployment()
                .setWebXML("spring-web.xml")
                .addAsWebInfResource("applicationContext.xml")
-               .addAsLibraries(resolveDependencies("org.springframework:spring-webmvc:5.3.20"))
+               // Necessary to enable CDI in EE 10 or fallback to CDI lite
+               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml")
+               .addAsLibraries(resolveDependencies("org.springframework:spring-webmvc"))
                .addClasses(SpringFeaturesBean.class, SpringFeaturesConfigProvider.class);
    }
 

--- a/integration-spring/src/test/java/org/ocpsoft/rewrite/spring/resolver/SpringBeanNameResolverIT.java
+++ b/integration-spring/src/test/java/org/ocpsoft/rewrite/spring/resolver/SpringBeanNameResolverIT.java
@@ -17,9 +17,12 @@ package org.ocpsoft.rewrite.spring.resolver;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara5;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteIT;
 
@@ -29,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Kaltepoth
  */
 @RunWith(Arquillian.class)
+@Category(IgnoreForPayara5.class)
 public class SpringBeanNameResolverIT extends RewriteIT
 {
  
@@ -37,8 +41,10 @@ public class SpringBeanNameResolverIT extends RewriteIT
    {
       return RewriteIT.getDeployment()
                .setWebXML("spring-web.xml")
-               .addAsLibraries(resolveDependencies("org.springframework:spring-webmvc:5.3.20"))
+               .addAsLibraries(resolveDependencies("org.springframework:spring-webmvc"))
                .addAsWebInfResource("applicationContext.xml")
+               // Necessary to enable CDI in EE 10 or fallback to CDI lite
+               .addAsWebInfResource(new StringAsset("<beans/>"), "beans.xml")
                .addClasses(SpringBeanNameResolverBean.class, SpringBeanNameResolverConfigProvider.class);
    }
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,20 @@
       
       <version.jakarta>9.1.0</version.jakarta>
       <version.spring>6.0.0-M4</version.spring>
-      
-      <ignoreSelectedFails>true</ignoreSelectedFails>
+   
+      <!-- Official Maven Plugins -->
+      <version.maven-compiler-plugin>3.10.1</version.maven-compiler-plugin>
+      <version.maven-jar-plugin>3.3.0</version.maven-jar-plugin>
+      <version.maven-dependency-plugin>3.3.0</version.maven-dependency-plugin>
+      <version.maven-shade-plugin>3.4.0</version.maven-shade-plugin>
+      <version.maven-surefire-plugin>3.0.0-M7</version.maven-surefire-plugin>
+      <version.maven-failsafe-plugin>3.0.0-M7</version.maven-failsafe-plugin>
+      <version.maven-plugin-plugin>3.6.4</version.maven-plugin-plugin>
+      <version.maven-site-plugin>4.0.0-M3</version.maven-site-plugin>
+      <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
+      <version.maven-javadoc-plugin>3.4.1</version.maven-javadoc-plugin>
+      <version.maven-release-plugin>3.0.0-M6</version.maven-release-plugin>
+      <version.maven-enforcer-plugin>3.1.0</version.maven-enforcer-plugin>
       
    </properties>
 
@@ -93,7 +105,6 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>${version.enforcer.plugin}</version>
             <configuration>
                <rules>
                   <requireJavaVersion>
@@ -104,11 +115,7 @@
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>${version.compiler.plugin}</version>
-            <configuration>
-               <release>${maven.compiler.release}</release>
-            </configuration>
+            <artifactId>maven-jar-plugin</artifactId>
          </plugin>
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -130,29 +137,78 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.22.2</version>
-            <executions>
-               <execution>
-                  <goals>
-                     <goal>integration-test</goal>
-                     <goal>verify</goal>
-                  </goals>
-               </execution>
-            </executions>
          </plugin>
       </plugins>
       <pluginManagement>
          <plugins>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-enforcer-plugin</artifactId>
+               <version>${version.maven-enforcer-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-compiler-plugin</artifactId>
+               <version>${version.maven-compiler-plugin}</version>
+               <configuration>
+                  <release>${maven.compiler.release}</release>
+               </configuration>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>
+               <version>${version.maven-jar-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-dependency-plugin</artifactId>
+               <version>${version.maven-dependency-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-shade-plugin</artifactId>
+               <version>${version.maven-shade-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
+               <version>${version.maven-surefire-plugin}</version>
                <configuration>
                   <argLine>-Xms256m -Xmx512m</argLine>
                </configuration>
             </plugin>
             <plugin>
                <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-failsafe-plugin</artifactId>
+               <version>${version.maven-failsafe-plugin}</version>
+               <executions>
+                  <execution>
+                     <goals>
+                        <goal>integration-test</goal>
+                        <goal>verify</goal>
+                     </goals>
+                  </execution>
+               </executions>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-plugin-plugin</artifactId>
+               <version>${version.maven-plugin-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-site-plugin</artifactId>
+               <version>${version.maven-site-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-source-plugin</artifactId>
+               <version>${version.maven-source-plugin}</version>
+            </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-javadoc-plugin</artifactId>
+               <version>${version.maven-javadoc-plugin}</version>
                <configuration>
                   <failOnError>false</failOnError>
                   <links>
@@ -162,6 +218,12 @@
                   <additionalparam>-Xdoclint:none</additionalparam>
                </configuration>
             </plugin>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-release-plugin</artifactId>
+               <version>${version.maven-release-plugin}</version>
+            </plugin>
+            
          </plugins>
       </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,16 +41,16 @@
       <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
       <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
       <version.arquillian.container.managed.payara>3.0.alpha6</version.arquillian.container.managed.payara>
-      
-      <version.payara>5.2022.3</version.payara>
-      <payara.home>${project.build.directory}/payara5</payara.home>
-      <it.ignore.forPayaraVersion>IgnoreForPayara5</it.ignore.forPayaraVersion>
-
-      <version.wildfly>26.1.2.Final</version.wildfly>
-      
-      <version.jakarta>9.1.0</version.jakarta>
-      <version.jakarta-faces.impl>3.0.2</version.jakarta-faces.impl>
+   
+      <version.jakarta>10.0.0</version.jakarta>
+      <version.jakarta-faces.impl>4.0.0</version.jakarta-faces.impl>
       <version.spring>6.0.0-M4</version.spring>
+   
+      <version.wildfly>27.0.0.Beta1</version.wildfly>
+   
+      <version.payara>6.2022.1.Alpha4</version.payara>
+      <payara.home>${project.build.directory}/payara6</payara.home>
+      <it.ignore.forPayaraVersion>IgnoreForPayara6</it.ignore.forPayaraVersion>
    
       <!-- Official Maven Plugins -->
       <version.maven-compiler-plugin>3.10.1</version.maven-compiler-plugin>
@@ -526,24 +526,24 @@
    <profiles>
       <profile>
          <id>EE9</id>
-         <activation>
-            <activeByDefault>true</activeByDefault>
-         </activation>
-         <!-- Intentionally left blank - used for CI matrix compatibility only -->
+         <properties>
+            <version.jakarta>9.1.0</version.jakarta>
+            <version.jakarta-faces.impl>3.0.2</version.jakarta-faces.impl>
+            
+            <version.wildfly>26.1.2.Final</version.wildfly>
+            
+            <version.payara>5.2022.3</version.payara>
+            <payara.home>${project.build.directory}/payara5</payara.home>
+            <it.ignore.forPayaraVersion>IgnoreForPayara5</it.ignore.forPayaraVersion>
+         </properties>
       </profile>
       
       <profile>
          <id>EE10</id>
-         <properties>
-            <version.jakarta>10.0.0</version.jakarta>
-            <version.jakarta-faces.impl>4.0.0</version.jakarta-faces.impl>
-            
-            <version.wildfly>27.0.0.Beta1</version.wildfly>
-            
-            <version.payara>6.2022.1.Alpha4</version.payara>
-            <payara.home>${project.build.directory}/payara6</payara.home>
-            <it.ignore.forPayaraVersion>IgnoreForPayara6</it.ignore.forPayaraVersion>
-         </properties>
+         <activation>
+            <activeByDefault>true</activeByDefault>
+         </activation>
+         <!-- Intentionally left blank - used for CI matrix compatibility only -->
       </profile>
       
       <!-- WILDFLY -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,10 @@
       <version.arquillian.drone>2.5.5</version.arquillian.drone>
       <version.arquillian.container.managed.wildfly>3.0.1.Final</version.arquillian.container.managed.wildfly>
       <version.arquillian.container.remote.wildfly>3.0.1.Final</version.arquillian.container.remote.wildfly>
+      <version.arquillian.container.managed.payara>2.4.6</version.arquillian.container.managed.payara>
+      
+      <version.payara>5.2022.3</version.payara>
+      <payara.home>${project.build.directory}/payara5</payara.home>
 
       <version.wildfly>26.1.1.Final</version.wildfly>
       
@@ -442,9 +446,15 @@
          <id>EE10</id>
          <properties>
             <version.jakarta>10.0.0</version.jakarta>
+            
             <version.wildfly>27.0.0.Beta1</version.wildfly>
+            
+            <version.payara>6.2022.1.Alpha4</version.payara>
+            <payara.home>${project.build.directory}/payara6</payara.home>
+            
             <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
             <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
+            <version.arquillian.container.managed.payara>3.0.alpha6</version.arquillian.container.managed.payara>
          </properties>
       </profile>
       
@@ -575,6 +585,87 @@
             </plugins>
          </build>
       </profile>
+      
+      
+      <!-- PAYARA -->
+      <profile>
+         <id>PAYARA_MANAGED</id>
+         <properties>
+            <skipTests>false</skipTests>
+         </properties>
+         <dependencies>
+            
+            <!-- Required since arquillian-payara 2.4 -->
+            <dependency>
+               <groupId>fish.payara.arquillian</groupId>
+               <artifactId>payara-client-ee9</artifactId>
+               <version>${version.arquillian.container.managed.payara}</version>
+            </dependency>
+         
+            <!-- Payara Server Container adaptor -->
+            <dependency>
+               <groupId>fish.payara.arquillian</groupId>
+               <artifactId>arquillian-payara-server-managed</artifactId>
+               <version>${version.arquillian.container.managed.payara}</version>
+               <scope>test</scope>
+            </dependency>
+         
+            <!-- Env Sync -->
+            <dependency>
+               <groupId>fish.payara.arquillian</groupId>
+               <artifactId>environment-setup</artifactId>
+               <version>${version.arquillian.container.managed.payara}</version>
+               <scope>test</scope>
+            </dependency>
+      
+         </dependencies>
+         <build>
+            <plugins>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-dependency-plugin</artifactId>
+                  <version>${version.dependency.plugin}</version>
+                  <executions>
+                     <execution>
+                        <id>unpack</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                           <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                           <artifactItems>
+                              <artifactItem>
+                                 <groupId>fish.payara.distributions</groupId>
+                                 <artifactId>payara</artifactId>
+                                 <version>${version.payara}</version>
+                                 <type>zip</type>
+                                 <overWrite>false</overWrite>
+                                 <outputDirectory>${project.build.directory}</outputDirectory>
+                              </artifactItem>
+                           </artifactItems>
+                        </configuration>
+                     </execution>
+                  </executions>
+               </plugin>
+               <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-failsafe-plugin</artifactId>
+                  <version>${version.failsafe.plugin}</version>
+                  <configuration>
+                     <excludedGroups>
+                        org.ocpsoft.rewrite.category.IgnoreForPayara
+                     </excludedGroups>
+                     <argLine>--illegal-access=debug --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+                     <systemPropertyVariables>
+                        <payara.home>${payara.home}</payara.home>
+                     </systemPropertyVariables>
+                  </configuration>
+               </plugin>
+            </plugins>
+         </build>
+      </profile>
+      
+      
    </profiles>
 
    <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.ocpsoft.rewrite</groupId>
    <artifactId>rewrite-parent</artifactId>
-   <version>5.0.0-SNAPSHOT</version>
+   <version>6.0.0-SNAPSHOT</version>
    <packaging>pom</packaging>
 
    <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
       <version.logging>1.0.5.Final</version.logging>
       <version.arquillian>1.6.0.Final</version.arquillian>
       <version.arquillian.drone>2.5.5</version.arquillian.drone>
+      <version.arquillian.container.managed.wildfly>3.0.1.Final</version.arquillian.container.managed.wildfly>
+      <version.arquillian.container.remote.wildfly>3.0.1.Final</version.arquillian.container.remote.wildfly>
 
       <version.wildfly>26.1.1.Final</version.wildfly>
       
@@ -441,6 +443,8 @@
          <properties>
             <version.jakarta>10.0.0</version.jakarta>
             <version.wildfly>27.0.0.Beta1</version.wildfly>
+            <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
+            <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
          </properties>
       </profile>
       
@@ -492,7 +496,7 @@
             <dependency>
                <groupId>org.wildfly.arquillian</groupId>
                <artifactId>wildfly-arquillian-container-managed</artifactId>
-               <version>4.0.0.Alpha4</version>
+               <version>${version.arquillian.container.managed.wildfly}</version>
                <scope>test</scope>
             </dependency>
          </dependencies>
@@ -504,7 +508,7 @@
             <dependency>
                <groupId>org.wildfly.arquillian</groupId>
                <artifactId>wildfly-arquillian-container-remote</artifactId>
-               <version>3.0.1.Final</version>
+               <version>${version.arquillian.container.remote.wildfly}</version>
                <scope>test</scope>
             </dependency>
          </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,10 @@
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
       <!-- JDK version -->
       <maven.compiler.release>11</maven.compiler.release>
-
+   
+      <!-- Allow to ignore some failing integration tests -->
+      <it.ignore.selectedFails>true</it.ignore.selectedFails>
+      
       <!-- Versions -->
       <version.junit>4.13.2</version.junit>
       <version.common>1.0.6.Final</version.common>

--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,15 @@
 
    <profiles>
       <profile>
+         <id>EE10</id>
+         <properties>
+            <version.jakarta>10.0.0</version.jakarta>
+            <version.wildfly>27.0.0.Beta1</version.wildfly>
+         </properties>
+      </profile>
+      
+      <!-- WILDFLY -->
+      <profile>
          <id>WILDFLY_MANAGED</id>
          <build>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,12 @@
          <email>github@larsgrefer.de</email>
          <timezone>Europe/Berlin</timezone>
       </developer>
+      <developer>
+         <id>poikilotherm</id>
+         <name>Oliver Bertuch</name>
+         <email>github@bertuch.eu</email>
+         <timezone>Europe/Berlin</timezone>
+      </developer>
    </developers>
 
    <url>https://ocpsoft.org/rewrite/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
       <version.wildfly>26.1.2.Final</version.wildfly>
       
       <version.jakarta>9.1.0</version.jakarta>
+      <version.jakarta-faces.impl>3.0.2</version.jakarta-faces.impl>
       <version.spring>6.0.0-M4</version.spring>
    
       <!-- Official Maven Plugins -->
@@ -452,7 +453,12 @@
             <type>pom</type>
             <scope>import</scope>
          </dependency>
-
+         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>${version.jakarta-faces.impl}</version>
+         </dependency>
+         
          <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-framework-bom</artifactId>
@@ -530,6 +536,7 @@
          <id>EE10</id>
          <properties>
             <version.jakarta>10.0.0</version.jakarta>
+            <version.jakarta-faces.impl>4.0.0</version.jakarta-faces.impl>
             
             <version.wildfly>27.0.0.Beta1</version.wildfly>
             

--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,9 @@
       <version.logging>1.0.5.Final</version.logging>
       <version.arquillian>1.6.0.Final</version.arquillian>
       <version.arquillian.drone>2.5.5</version.arquillian.drone>
-      <version.arquillian.container.managed.wildfly>3.0.1.Final</version.arquillian.container.managed.wildfly>
-      <version.arquillian.container.remote.wildfly>3.0.1.Final</version.arquillian.container.remote.wildfly>
-      <version.arquillian.container.managed.payara>2.4.6</version.arquillian.container.managed.payara>
+      <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
+      <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
+      <version.arquillian.container.managed.payara>3.0.alpha6</version.arquillian.container.managed.payara>
       
       <version.payara>5.2022.3</version.payara>
       <payara.home>${project.build.directory}/payara5</payara.home>
@@ -451,10 +451,6 @@
             
             <version.payara>6.2022.1.Alpha4</version.payara>
             <payara.home>${project.build.directory}/payara6</payara.home>
-            
-            <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
-            <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
-            <version.arquillian.container.managed.payara>3.0.alpha6</version.arquillian.container.managed.payara>
          </properties>
       </profile>
       

--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,14 @@
 
    <profiles>
       <profile>
+         <id>EE9</id>
+         <activation>
+            <activeByDefault>true</activeByDefault>
+         </activation>
+         <!-- Intentionally left blank - used for CI matrix compatibility only -->
+      </profile>
+      
+      <profile>
          <id>EE10</id>
          <properties>
             <version.jakarta>10.0.0</version.jakarta>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <version.payara>5.2022.3</version.payara>
       <payara.home>${project.build.directory}/payara5</payara.home>
 
-      <version.wildfly>26.1.1.Final</version.wildfly>
+      <version.wildfly>26.1.2.Final</version.wildfly>
       
       <version.jakarta>9.1.0</version.jakarta>
       <version.spring>6.0.0-M4</version.spring>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
       
       <version.payara>5.2022.3</version.payara>
       <payara.home>${project.build.directory}/payara5</payara.home>
+      <it.ignore.forPayaraVersion>IgnoreForPayara5</it.ignore.forPayaraVersion>
 
       <version.wildfly>26.1.2.Final</version.wildfly>
       
@@ -467,6 +468,7 @@
             
             <version.payara>6.2022.1.Alpha4</version.payara>
             <payara.home>${project.build.directory}/payara6</payara.home>
+            <it.ignore.forPayaraVersion>IgnoreForPayara6</it.ignore.forPayaraVersion>
          </properties>
       </profile>
       
@@ -665,7 +667,8 @@
                   <version>${version.failsafe.plugin}</version>
                   <configuration>
                      <excludedGroups>
-                        org.ocpsoft.rewrite.category.IgnoreForPayara
+                        org.ocpsoft.rewrite.category.IgnoreForPayara,
+                        ${it.ignore.forPayaraVersion}
                      </excludedGroups>
                      <argLine>--illegal-access=debug --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
                      <systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,10 @@
       <!-- Encoding -->
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <!-- JDK version -->
+      <!-- Target Java version for compatibility -->
       <maven.compiler.release>11</maven.compiler.release>
+      <!-- Minimum JDK necessary to successfully compile and test -->
+      <maven.enforce.jdk>17.0.0</maven.enforce.jdk>
    
       <!-- Allow to ignore some failing integration tests -->
       <it.ignore.selectedFails>true</it.ignore.selectedFails>
@@ -111,7 +113,7 @@
             <configuration>
                <rules>
                   <requireJavaVersion>
-                     <version>17.0.0</version>
+                     <version>${maven.enforce.jdk}</version>
                   </requireJavaVersion>
                </rules>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -551,7 +551,7 @@
                <plugin>
                   <groupId>org.wildfly.plugins</groupId>
                   <artifactId>wildfly-maven-plugin</artifactId>
-                  <version>3.0.1.Final</version>
+                  <version>3.0.2.Final</version>
                   <executions>
                      <execution>
                         <id>start-wildfly</id>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
       <version.jakarta>9.1.0</version.jakarta>
       <version.spring>6.0.0-M4</version.spring>
       
+      <ignoreSelectedFails>true</ignoreSelectedFails>
+      
    </properties>
 
    <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,12 @@
 
    <repositories>
       <repository>
+         <id>central-repo</id>
+         <name>Central Repository</name>
+         <url>https://repo1.maven.org/maven2</url>
+         <layout>default</layout>
+      </repository>
+      <repository>
          <id>spring-milestones</id>
          <name>Spring Milestones</name>
          <url>https://repo.spring.io/milestone</url>

--- a/rewrite-servlet/pom.xml
+++ b/rewrite-servlet/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/security-integration-shiro/pom.xml
+++ b/security-integration-shiro/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/security-integration-shiro/pom.xml
+++ b/security-integration-shiro/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>true</testFailureIgnore>
+               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/security-integration-shiro/pom.xml
+++ b/security-integration-shiro/pom.xml
@@ -60,7 +60,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
                <!--TODO: fix Integration tests-->
-               <testFailureIgnore>${ignoreSelectedFails}</testFailureIgnore>
+               <testFailureIgnore>${it.ignore.selectedFails}</testFailureIgnore>
             </configuration>
          </plugin>
       </plugins>

--- a/showcase/access-control/pom.xml
+++ b/showcase/access-control/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-showcase</artifactId>
       <groupId>org.ocpsoft.rewrite.showcase</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/showcase/bookstore/pom.xml
+++ b/showcase/bookstore/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-showcase</artifactId>
       <groupId>org.ocpsoft.rewrite.showcase</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/showcase/composite-query/pom.xml
+++ b/showcase/composite-query/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-showcase</artifactId>
       <groupId>org.ocpsoft.rewrite.showcase</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/showcase/pom.xml
+++ b/showcase/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>rewrite-parent</artifactId>
 		<groupId>org.ocpsoft.rewrite</groupId>
-		<version>5.0.0-SNAPSHOT</version>
+		<version>6.0.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 

--- a/showcase/rest-ws/pom.xml
+++ b/showcase/rest-ws/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <artifactId>rewrite-showcase</artifactId>
       <groupId>org.ocpsoft.rewrite.showcase</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/showcase/transform/pom.xml
+++ b/showcase/transform/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-showcase</artifactId>
       <groupId>org.ocpsoft.rewrite.showcase</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/test-base/pom.xml
+++ b/test-base/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara.java
+++ b/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara.java
@@ -1,0 +1,7 @@
+package org.ocpsoft.rewrite.category;
+
+/**
+ * JUnit category which will prevent a certain test to be executed when running the test suite with Payara.
+ */
+public interface IgnoreForPayara {
+}

--- a/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara5.java
+++ b/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara5.java
@@ -1,0 +1,4 @@
+package org.ocpsoft.rewrite.category;
+
+public interface IgnoreForPayara5 {
+}

--- a/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara6.java
+++ b/test-base/src/main/java/org/ocpsoft/rewrite/category/IgnoreForPayara6.java
@@ -1,0 +1,4 @@
+package org.ocpsoft.rewrite.category;
+
+public interface IgnoreForPayara6 {
+}

--- a/test-harness/pom.xml
+++ b/test-harness/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <artifactId>rewrite-parent</artifactId>
       <groupId>org.ocpsoft.rewrite</groupId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/transform-less/pom.xml
+++ b/transform-less/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/transform-markup/pom.xml
+++ b/transform-markup/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/transform-minify/pom.xml
+++ b/transform-minify/pom.xml
@@ -26,18 +26,37 @@
          <artifactId>jakarta.servlet-api</artifactId>
          <scope>provided</scope>
       </dependency>
-
+      
+      <!-- CSS Minify -->
       <dependency>
          <groupId>de.larsgrefer.sass</groupId>
          <artifactId>sass-embedded-host</artifactId>
-         <version>1.3.2</version>
+         <version>1.5.1</version>
       </dependency>
+      <dependency>
+         <groupId>de.larsgrefer.sass</groupId>
+         <artifactId>sass-embedded-protocol</artifactId>
+         <version>1.5.1</version>
+      </dependency>
+      <dependency>
+         <groupId>com.google.protobuf</groupId>
+         <artifactId>protobuf-java</artifactId>
+         <version>3.21.8</version>
+      </dependency>
+      
+      <!-- JS Minify -->
       <dependency>
          <groupId>com.yahoo.platform.yui</groupId>
          <artifactId>yuicompressor</artifactId>
          <version>2.4.8</version>
       </dependency>
-
+      <dependency>
+         <groupId>rhino</groupId>
+         <artifactId>js</artifactId>
+         <version>1.7R2</version>
+         <scope>runtime</scope>
+      </dependency>
+   
       <dependency>
          <groupId>org.ocpsoft.rewrite</groupId>
          <artifactId>rewrite-test-harness</artifactId>

--- a/transform-minify/pom.xml
+++ b/transform-minify/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 

--- a/transform-minify/src/main/java/org/ocpsoft/rewrite/transform/minify/Minify.java
+++ b/transform-minify/src/main/java/org/ocpsoft/rewrite/transform/minify/Minify.java
@@ -1,6 +1,7 @@
 package org.ocpsoft.rewrite.transform.minify;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.ocpsoft.rewrite.transform.Transformer;
 
@@ -11,7 +12,7 @@ import org.ocpsoft.rewrite.transform.Transformer;
  */
 public abstract class Minify implements Transformer
 {
-   private Charset charset = Charset.forName("UTF-8");
+   private Charset charset = StandardCharsets.UTF_8;
 
    /**
     * Specify the {@link Charset} to be used during minification.

--- a/transform-minify/src/test/java/org/ocpsoft/rewrite/transform/minify/CssMinifyIT.java
+++ b/transform-minify/src/test/java/org/ocpsoft/rewrite/transform/minify/CssMinifyIT.java
@@ -15,8 +15,6 @@
  */
 package org.ocpsoft.rewrite.transform.minify;
 
-import java.io.File;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -24,12 +22,12 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.ocpsoft.rewrite.category.IgnoreForWildfly;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.test.HttpAction;
 import org.ocpsoft.rewrite.test.RewriteIT;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +48,8 @@ public class CssMinifyIT extends RewriteIT
                .addAsWebResource(new StringAsset(".class {\n  width : 100px;\n}"), "test.css")
                .addAsLibraries(getTransformArchive())
                .addAsLibraries(resolveDependency("com.yahoo.platform.yui:yuicompressor"))
+               .addAsLibraries(resolveDependencies("de.larsgrefer.sass:sass-embedded-host"))
+               .addAsLibraries(resolveDependencies("de.larsgrefer.sass:sass-embedded-protocol"))
                .addClasses(CssMinifyTestProvider.class)
                .addAsServiceProvider(ConfigurationProvider.class, CssMinifyTestProvider.class);
    }
@@ -62,14 +62,8 @@ public class CssMinifyIT extends RewriteIT
 
       return archive;
    }
-
-   /**
-    * Ignored on Wildlfy because there seems to be some issue with the content length.
-    * 
-    * @see https://github.com/ocpsoft/rewrite/issues/145
-    */
+   
    @Test
-   @Category(IgnoreForWildfly.class)
    public void testCssFileCompression() throws Exception
    {
       HttpAction action = get("/test.css");
@@ -78,7 +72,6 @@ public class CssMinifyIT extends RewriteIT
    }
 
    @Test
-   @Category(IgnoreForWildfly.class)
    public void testNotExistingSourceFile() throws Exception
    {
       HttpAction action = get("/not-existing.css");

--- a/transform-minify/src/test/java/org/ocpsoft/rewrite/transform/minify/JsMinifyIT.java
+++ b/transform-minify/src/test/java/org/ocpsoft/rewrite/transform/minify/JsMinifyIT.java
@@ -22,6 +22,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.ocpsoft.rewrite.category.IgnoreForPayara;
 import org.ocpsoft.rewrite.category.IgnoreForWildfly;
 import org.ocpsoft.rewrite.config.ConfigurationProvider;
 import org.ocpsoft.rewrite.test.HttpAction;
@@ -57,7 +58,7 @@ public class JsMinifyIT extends RewriteIT
     * @see https://github.com/ocpsoft/rewrite/issues/145
     */
    @Test
-   @Category(IgnoreForWildfly.class)
+   @Category({IgnoreForWildfly.class, IgnoreForPayara.class})
    public void testJavaScriptCompression() throws Exception
    {
       HttpAction action = get("/test.js");
@@ -66,7 +67,7 @@ public class JsMinifyIT extends RewriteIT
    }
 
    @Test
-   @Category(IgnoreForWildfly.class)
+   @Category({IgnoreForWildfly.class, IgnoreForPayara.class})
    public void testNotExistingSourceFile() throws Exception
    {
       HttpAction action = get("/not-existing.js");

--- a/transform/pom.xml
+++ b/transform/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.ocpsoft.rewrite</groupId>
       <artifactId>rewrite-parent</artifactId>
-      <version>5.0.0-SNAPSHOT</version>
+      <version>6.0.0-SNAPSHOT</version>
       <relativePath>../</relativePath>
    </parent>
 


### PR DESCRIPTION
- Add integration testing with Payara in addition to Wildfly
- Fix tests for EE10 (CDI and Faces changes)
- If missing code changes discovered via testing, add here, too

Closes #345 

Discoveries so far:
- Tests using CDI or Faces need proper configuration of CDI via `beans.xml`. Discovery mode seems to be necessary to be set to `all`, which is different than the default `annotated`! [See spec](https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#_jakarta_contexts_and_dependency_injection_4_0) This means that any app using this lib via CDI or Jakarta Faces will need to enable this discovery mode, too! (This should be documented and maybe fixed at a later point in time.)

TODOs:
- [x] Refactor Jakarta Faces using tests, adapting to changed specs.
- [ ] Add docs