### PR TITLE
EE10: Update to newest Payara 6.x and 5.x releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
       <version.arquillian.drone>2.5.5</version.arquillian.drone>
       <version.arquillian.container.managed.wildfly>5.0.0.Alpha5</version.arquillian.container.managed.wildfly>
       <version.arquillian.container.remote.wildfly>5.0.0.Alpha5</version.arquillian.container.remote.wildfly>
-      <version.arquillian.container.managed.payara>3.0.alpha6</version.arquillian.container.managed.payara>
+      <version.arquillian.container.managed.payara>3.0.alpha7</version.arquillian.container.managed.payara>
    
       <version.jakarta>10.0.0</version.jakarta>
       <version.jakarta-faces.impl>4.0.0</version.jakarta-faces.impl>
@@ -48,7 +48,7 @@
    
       <version.wildfly>27.0.0.Beta1</version.wildfly>
    
-      <version.payara>6.2022.1.Alpha4</version.payara>
+      <version.payara>6.2022.1</version.payara>
       <payara.home>${project.build.directory}/payara6</payara.home>
       <it.ignore.forPayaraVersion>IgnoreForPayara6</it.ignore.forPayaraVersion>
    
@@ -571,7 +571,7 @@
             
             <version.wildfly>26.1.2.Final</version.wildfly>
             
-            <version.payara>5.2022.3</version.payara>
+            <version.payara>5.2022.4</version.payara>
             <payara.home>${project.build.directory}/payara5</payara.home>
             <it.ignore.forPayaraVersion>IgnoreForPayara5</it.ignore.forPayaraVersion>
          </properties>


### PR DESCRIPTION
As releases happened yesterday, upgrading from 6.Alpha releases to final plus adapting latest 5.x series release containing lots of fixes.

See also:
- https://github.com/payara/Payara/releases/tag/payara-server-6.2022.1
- https://github.com/payara/Payara/releases/tag/payara-server-5.2022.4

FWIW: it looks like Wildfly is about to release soonish, too, when looking at the commit descs at https://github.com/wildfly/wildfly