### PR TITLE
Prevent double-encoding of URLs in config-prettyfaces

### DIFF
--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/application/PrettyRedirector.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/application/PrettyRedirector.java
@@ -69,7 +69,7 @@ public class PrettyRedirector
             UrlMapping mapping = config.getMappingById(action);
             if (mapping != null)
             {
-               String target = contextPath + builder.buildURL(mapping).encode()
+               String target = contextPath + builder.buildURL(mapping)
                         + builder.buildQueryString(mapping);
                log.trace("Redirecting to mappingId [" + mapping.getId() + "], [" + target + "]");
                encodeURL(externalContext, config, target);

--- a/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/dynaview/DynaviewEngine.java
+++ b/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/config/dynaview/DynaviewEngine.java
@@ -163,7 +163,7 @@ public class DynaviewEngine
                urlMapping = context.getConfig().getMappingById(viewId);
                viewId = urlMapping.getViewId();
                ExtractedValuesURLBuilder builder = new ExtractedValuesURLBuilder();
-               result = context.getContextPath() + builder.buildURL(urlMapping).encode()
+               result = context.getContextPath() + builder.buildURL(urlMapping)
                          + builder.buildQueryString(urlMapping);
             }
             else


### PR DESCRIPTION
URLs are being double-encoded, resulting in e.g. `%2520` for a space character.

The URL returned by `ExtractedValuesURLBuilder.buildURL` is already encoded here: https://github.com/ocpsoft/rewrite/blob/b33b345dad027ba812d90b50d20929540ab7aa19/config-prettyfaces/src/main/java/com/ocpsoft/pretty/faces/beans/ExtractedValuesURLBuilder.java#L89 so it should not be encoded again.